### PR TITLE
Scaffold backend and frontend for BizDetails AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# bizdetails-Ai-final
+# BizDetails AI
+
+This repository contains a minimal skeleton for the **BizDetails AI** platform.
+
+## Backend
+
+A basic [FastAPI](https://fastapi.tiangolo.com/) app with placeholder endpoints lives in `backend/app/main.py`. The endpoints include authentication, file upload, data processing, results retrieval, dashboard stats, and a chat interface.
+
+To install dependencies and run the API locally:
+
+```bash
+pip install -r backend/requirements.txt
+uvicorn backend.app.main:app --reload
+```
+
+## Frontend
+
+Frontend implementation is not yet provided. A future iteration would use React and Tailwind CSS to implement the upload flow, results view, dashboard, and chat panel described in the project plan.
+
+## Tests
+
+No automated tests are included. Run `pytest` to execute an empty test suite.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,66 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+app = FastAPI(title="BizDetails AI API")
+
+
+class UserCredentials(BaseModel):
+    email: str
+    password: str
+
+
+class ProcessRequest(BaseModel):
+    mapping: dict
+
+
+@app.post("/api/auth/signup")
+async def signup(credentials: UserCredentials):
+    """Register a new user. Placeholder implementation."""
+    return {"message": "signup not implemented"}
+
+
+@app.post("/api/auth/signin")
+async def signin(credentials: UserCredentials):
+    """Authenticate a user. Placeholder implementation."""
+    return {"token": "fake-jwt-token"}
+
+
+@app.post("/api/upload")
+async def upload(file: UploadFile = File(...)):
+    """Accept a CSV file and return placeholder headers."""
+    return {"headers": ["Company Name", "Country", "Industry"]}
+
+
+@app.post("/api/process")
+async def process(req: ProcessRequest):
+    """Start background enrichment task. Placeholder implementation."""
+    return {"task_id": "example-task-id"}
+
+
+@app.get("/api/results")
+async def get_results():
+    """Return enriched results. Placeholder implementation."""
+    return {"results": []}
+
+
+@app.get("/api/results/{task_id}/status")
+async def task_status(task_id: str):
+    """Return task status. Placeholder implementation."""
+    return {"task_id": task_id, "status": "pending"}
+
+
+@app.get("/api/dashboard")
+async def dashboard():
+    """Return dashboard statistics. Placeholder implementation."""
+    return {"stats": {}}
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+@app.post("/api/chat")
+async def chat(req: ChatRequest):
+    """Proxy user message to LLM. Placeholder implementation."""
+    return {"response": "Chat endpoint not implemented."}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>BizDetails AI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bizdetails-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function App() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">BizDetails AI</h1>
+      <p>Frontend scaffold not yet implemented.</p>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- add FastAPI API skeleton with auth, upload, process, results, dashboard, and chat endpoints
- stub React + Vite frontend scaffold
- update README with project structure and instructions

## Testing
- `python -m pytest`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6892678387ec83248a8ea7abf2c672f6