### PR TITLE
Refine frontend layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,13 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>BizDetails AI</title>
+    <meta
+      name="description"
+      content="BizDetails AI – upload company lists, map domains, and view results with an AI assistant"
+    />
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body class="min-h-screen">
+  <body class="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,9 +20,6 @@ import { ChatPanel } from './components/ChatPanel';
 import { ComplianceBanner } from './components/ComplianceBanner';
 import { LandingPage } from './components/LandingPage';
 
-// NOTE: Ensure generateMockResults is imported if used
-//import { generateMockResults } from './utils/mockData';
-
 const API = import.meta.env.VITE_API_BASE;
 
 export default function App() {
@@ -57,13 +54,32 @@ export default function App() {
       setProcessedResults(generateMockResults(mappedData));
       setActiveTab('results');
       setUploadStep('upload');
-    }, 0);
+    }, 2000);
   };
 
   const handleBackToUpload = () => {
     setUploadStep('upload');
     setUploadedFile(null);
   };
+
+  const generateMockDomain = (companyName) => {
+    const cleanName = companyName.toLowerCase().replace(/[^a-z0-9]/g, '');
+    const domains = ['.com', '.io', '.co', '.net'];
+    return `${cleanName}${domains[Math.floor(Math.random() * domains.length)]}`;
+  };
+
+  const generateMockResults = (data) =>
+    data.map((row, index) => ({
+      id: index + 1,
+      companyName: row['Company Name'] || `Company ${index + 1}`,
+      originalData: row,
+      domain: generateMockDomain(row['Company Name'] || `Company ${index + 1}`),
+      confidence: ['High', 'Medium', 'Low'][Math.floor(Math.random() * 3)],
+      matchType: ['Exact', 'Contextual', 'Reverse', 'Manual'][Math.floor(Math.random() * 4)],
+      notes: Math.random() > 0.7 ? 'Fuzzy match applied' : null,
+      country: row.Country || 'US',
+      industry: row.Industry || 'Technology',
+    }));
 
   const getUploadTabContent = () => {
     switch (uploadStep) {
@@ -134,40 +150,44 @@ export default function App() {
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex gap-6">
-        <div className={`flex-1 transition-all duration-300 ${showChat ? 'mr-80' : ''}`}>
-          <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <TabsList className="grid w-full grid-cols-3 mb-8">
-              <TabsTrigger value="upload" className="flex items-center gap-2">
-                {uploadStep === 'mapping' ? <Settings className="w-4 h-4" /> : <Upload className="w-4 h-4" />}
-                {uploadStep === 'mapping' ? 'Column Mapping' : 'Upload & Map'}
-              </TabsTrigger>
-              <TabsTrigger value="results" className="flex items-center gap-2">
-                <FileText className="w-4 h-4" /> Results
-              </TabsTrigger>
-              <TabsTrigger value="dashboard" className="flex items-center gap-2">
-                <BarChart3 className="w-4 h-4" /> Dashboard
-              </TabsTrigger>
-            </TabsList>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex gap-6">
+          <div className={`flex-1 transition-all duration-300 ${showChat ? 'mr-80' : ''}`}>
+            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+              <TabsList className="grid w-full grid-cols-3 mb-8">
+                <TabsTrigger value="upload" className="flex items-center gap-2">
+                  {uploadStep === 'mapping' ? <Settings className="w-4 h-4" /> : <Upload className="w-4 h-4" />}
+                  {uploadStep === 'mapping' ? 'Column Mapping' : 'Upload & Map'}
+                </TabsTrigger>
+                <TabsTrigger value="results" className="flex items-center gap-2">
+                  <FileText className="w-4 h-4" />
+                  Results
+                </TabsTrigger>
+                <TabsTrigger value="dashboard" className="flex items-center gap-2">
+                  <BarChart3 className="w-4 h-4" />
+                  Dashboard
+                </TabsTrigger>
+              </TabsList>
 
-            <TabsContent value="upload" className="space-y-6">
-              {getUploadTabContent()}
-            </TabsContent>
-            <TabsContent value="results" className="space-y-6">
-              <ResultsView results={processedResults} />
-            </TabsContent>
-            <TabsContent value="dashboard" className="space-y-6">
-              <Dashboard />
-            </TabsContent>
-          </Tabs>
-        </div>
-
-        {showChat && (
-          <div className="fixed right-6 top-24 bottom-6 w-80">
-            <ChatPanel onClose={() => setShowChat(false)} />
+              <TabsContent value="upload" className="space-y-6">
+                {getUploadTabContent()}
+              </TabsContent>
+              <TabsContent value="results" className="space-y-6">
+                <ResultsView results={processedResults} />
+              </TabsContent>
+              <TabsContent value="dashboard" className="space-y-6">
+                <Dashboard />
+              </TabsContent>
+            </Tabs>
           </div>
-        )}
-      </main>
+
+          {showChat && (
+            <div className="fixed right-6 top-24 bottom-6 w-80">
+              <ChatPanel onClose={() => setShowChat(false)} />
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -27,66 +27,130 @@ export function LandingPage({ onSignIn }) {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-purple-50">
-      <form
-        onSubmit={handleSubmit}
-        className="bg-white p-8 rounded shadow w-80 space-y-4"
-      >
-        <h2 className="text-xl font-semibold text-center">
-          {isSignup ? 'Sign Up' : 'Sign In'}
-        </h2>
-        <input
-          type="email"
-          required
-          placeholder="Email"
-          className="w-full border px-2 py-1 rounded"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <input
-          type="text"
-          placeholder="Name"
-          className="w-full border px-2 py-1 rounded"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <input
-          type="password"
-          required
-          placeholder="Password"
-          className="w-full border px-2 py-1 rounded"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <Button type="submit" className="w-full">
-          {isSignup ? 'Sign Up' : 'Sign In'}
-        </Button>
-        <div className="text-sm text-center">
-          {isSignup ? (
-            <>
-              Already have an account?{' '}
-              <button
-                type="button"
-                className="text-blue-600 underline"
-                onClick={() => setIsSignup(false)}
-              >
-                Sign In
-              </button>
-            </>
-          ) : (
-            <>
-              Need an account?{' '}
-              <button
-                type="button"
-                className="text-blue-600 underline"
-                onClick={() => setIsSignup(true)}
-              >
-                Sign Up
-              </button>
-            </>
-          )}
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 flex items-center p-6">
+      <div className="max-w-5xl mx-auto grid md:grid-cols-2 gap-12 items-center">
+        <div className="space-y-6">
+          <div>
+            <h1 className="text-4xl font-bold text-gray-900">BizDetails AI</h1>
+            <p className="text-lg text-gray-700">Enriching Business Data with AI Precision</p>
+          </div>
+          <div className="flex items-center space-x-3">
+            <span className="px-3 py-1 bg-purple-100 text-purple-700 text-sm rounded-full">Beta Access</span>
+            <span className="text-sm text-gray-600">Powered by Advanced AI</span>
+          </div>
+          <p className="text-gray-700">
+            Enrich Your Business Data with AI Precision. Transform incomplete company
+            data into comprehensive business intelligence. Map domains, validate details,
+            and enrich your database with AI-powered accuracy.
+          </p>
+          <ul className="space-y-2 text-gray-700">
+            <li>
+              <strong>Precise Domain Mapping</strong> – AI-powered matching of company
+              names to their verified business websites with 95%+ accuracy
+            </li>
+            <li>
+              <strong>Global Data Enrichment</strong> – Identify regional domains,
+              subsidiaries, and international business presence
+            </li>
+            <li>
+              <strong>Context-Aware Intelligence</strong> – Leverages industry,
+              location, and company details for intelligent data enhancement
+            </li>
+            <li>
+              <strong>Complete Business Profiles</strong> – Build comprehensive company
+              profiles with verified domains and business details
+            </li>
+          </ul>
+          <div>
+            <h3 className="font-semibold">Perfect for:</h3>
+            <ul className="grid grid-cols-2 gap-1 text-gray-700 text-sm">
+              <li>B2B Sales Lead Generation</li>
+              <li>Marketing Campaign Targeting</li>
+              <li>Data Enrichment & Cleansing</li>
+              <li>Competitive Intelligence</li>
+              <li>Account-Based Marketing</li>
+              <li>CRM Data Enhancement</li>
+            </ul>
+          </div>
+          <div className="flex gap-6 text-center">
+            <div>
+              <p className="text-2xl font-bold">95%</p>
+              <p className="text-xs text-gray-500">Accuracy Rate</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold">2.3s</p>
+              <p className="text-xs text-gray-500">Avg Processing</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold">150+</p>
+              <p className="text-xs text-gray-500">Countries</p>
+            </div>
+          </div>
         </div>
-      </form>
+
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white p-8 rounded shadow w-full space-y-4"
+        >
+          <h2 className="text-xl font-semibold text-center">
+            {isSignup ? 'Sign Up' : 'Sign In'}
+          </h2>
+          <input
+            type="text"
+            placeholder="Enter your full name"
+            className="w-full border px-2 py-1 rounded"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <input
+            type="email"
+            required
+            placeholder="Enter your email"
+            className="w-full border px-2 py-1 rounded"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <input
+            type="password"
+            required
+            placeholder="Password"
+            className="w-full border px-2 py-1 rounded"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button type="submit" className="w-full">
+            {isSignup ? 'Start Enriching Data' : 'Sign In'}
+          </Button>
+          <div className="text-xs text-gray-500 text-center">
+            GDPR & CCPA Compliant • Enterprise-Grade Security • No Credit Card Required
+          </div>
+          <div className="text-sm text-center">
+            {isSignup ? (
+              <>
+                Already have an account?{' '}
+                <button
+                  type="button"
+                  className="text-blue-600 underline"
+                  onClick={() => setIsSignup(false)}
+                >
+                  Sign In
+                </button>
+              </>
+            ) : (
+              <>
+                Need an account?{' '}
+                <button
+                  type="button"
+                  className="text-blue-600 underline"
+                  onClick={() => setIsSignup(true)}
+                >
+                  Sign Up
+                </button>
+              </>
+            )}
+          </div>
+        </form>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add mock data generators for domains and results
- simulate processing delay and reorganize content layout
- expand landing page with marketing copy while keeping auth forms

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892ba473fd88324bba44d9a5ed4f58a