### PR TITLE
Add preprocessing and mapping for company data

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ sqlalchemy==2.0.42
 psycopg2-binary==2.9.10
 passlib[bcrypt]==1.7.4
 fastapi-jwt-auth==0.5.0
+pycountry==22.3.5


### PR DESCRIPTION
## Summary
- add preprocessing utilities for company name normalization, ISO country codes, industry taxonomy and deduplication
- extend `/api/process` to accept column mapping and run preprocessing before generating results
- include `pycountry` dependency for country normalization

## Testing
- `python -m pytest`
- `pip install -r backend/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_689304302ac88324a111228bbb50ecf5