### PR TITLE
feat: persist session across refresh

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -232,6 +232,16 @@ def signin(
     return {"access_token": access_token}
 
 
+@app.get("/api/auth/verify")
+def verify_token(authorize: AuthJWT = Depends()):
+    try:
+        authorize.jwt_required()
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    current_user = authorize.get_jwt_subject()
+    return {"email": current_user}
+
+
 # ---- Upload & processing ----
 
 @app.post("/api/upload")


### PR DESCRIPTION
## Summary
- add JWT verification endpoint to backend
- keep signed-in user and active tab in localStorage
- restore session on load and clear storage on logout

## Testing
- `python -m py_compile backend/app/main.py backend/app/models.py backend/app/database.py backend/app/__init__.py`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893218387488324adb4f21bab523d0c