### PR TITLE
Expose enriched company details in results view

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,6 +56,9 @@ class ProcessedResult(BaseModel):
     companyName: str
     originalData: Dict[str, Optional[str]]
     domain: str
+    hq: str
+    size: str
+    linkedin_url: str
     confidence: str
     matchType: str
     notes: Optional[str]
@@ -199,9 +202,12 @@ def enrich_domains(
             results.append(
                 ProcessedResult(
                     id=idx,
-                    companyName=company.name or "",
+                    companyName=company.name or (row.get("Company Name") or ""),
                     originalData=row,
                     domain=company.domain or domain,
+                    hq=company.hq or "",
+                    size=company.size or "",
+                    linkedin_url=company.linkedin_url or "",
                     confidence="High",
                     matchType=match_type,
                     notes=None,
@@ -213,14 +219,17 @@ def enrich_domains(
             results.append(
                 ProcessedResult(
                     id=idx,
-                    companyName="",
+                    companyName=row.get("Company Name") or "",
                     originalData=row,
                     domain=domain,
+                    hq=row.get("HQ") or "",
+                    size=row.get("Company Size") or row.get("Size") or "",
+                    linkedin_url=row.get("LinkedIn URL") or "",
                     confidence="Low",
                     matchType="None",
                     notes=note or "Not found",
-                    country="",
-                    industry="",
+                    country=row.get("Country") or "",
+                    industry=row.get("Industry") or "",
                 )
             )
     return results

--- a/frontend/src/components/ResultsView.jsx
+++ b/frontend/src/components/ResultsView.jsx
@@ -9,10 +9,12 @@ export function ResultsView({ results }) {
     <table className="min-w-full text-left border">
       <thead>
         <tr>
-          <th className="border px-2">Company</th>
-          <th className="border px-2">Domain</th>
-          <th className="border px-2">Confidence</th>
-          <th className="border px-2">Match Type</th>
+          <th className="border px-2">Company Name</th>
+          <th className="border px-2">Website</th>
+          <th className="border px-2">Headquarters</th>
+          <th className="border px-2">Industry</th>
+          <th className="border px-2">Employee Size</th>
+          <th className="border px-2">Company LinkedIn</th>
         </tr>
       </thead>
       <tbody>
@@ -20,8 +22,10 @@ export function ResultsView({ results }) {
           <tr key={r.id}>
             <td className="border px-2">{r.companyName}</td>
             <td className="border px-2">{r.domain}</td>
-            <td className="border px-2">{r.confidence}</td>
-            <td className="border px-2">{r.matchType}</td>
+            <td className="border px-2">{r.hq}</td>
+            <td className="border px-2">{r.industry}</td>
+            <td className="border px-2">{r.size}</td>
+            <td className="border px-2">{r.linkedin_url}</td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
## Summary
- include HQ, employee size, LinkedIn URL in backend enrichment output
- return user-provided fields when company is not found
- display enriched company fields in results table

## Testing
- `python -m py_compile backend/app/main.py`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689632eef04083248d39f0d8836ca26e