### PR TITLE
Track user profile and activity metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains a minimal skeleton for the **BizDetails AI** platform.
 
 A basic [FastAPI](https://fastapi.tiangolo.com/) app with placeholder endpoints lives in `backend/app/main.py`. The endpoints include authentication, file upload, data processing, results retrieval, dashboard stats, and a chat interface.
 
+Each user record stores the user's full name, role (e.g., Sales, Marketing, Data Analyst), enrichment count, last login timestamp, and account status.
+
 To install dependencies and run the API locally:
 
 ```bash

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, DateTime
 from sqlalchemy.dialects.postgresql import ARRAY
 from .database import Base
 
@@ -9,6 +9,11 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
+    full_name = Column(String, nullable=False)
+    role = Column(String, nullable=False)
+    enrichment_count = Column(Integer, default=0, nullable=False)
+    last_login = Column(DateTime, nullable=True)
+    account_status = Column(String, default="Active", nullable=False)
 
 
 class CompanyUpdated(Base):


### PR DESCRIPTION
## Summary
- expand user model with full name, role, enrichment count, last login and account status
- capture name and role during signup and record last login on signin
- require auth for processing and increment user enrichment count

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689664c853b083248369ff7776d43882