### PR TITLE
fix: allow signup with alternate name field

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI, UploadFile, File, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi_jwt_auth import AuthJWT
 from passlib.context import CryptContext
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, root_validator
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
@@ -58,6 +58,13 @@ class UserSignup(BaseModel):
     password: str
     full_name: str = Field(..., alias="fullName")
     role: UserRole
+
+    @root_validator(pre=True)
+    def populate_fullname(cls, values):
+        # Accept "name" as an alternative to "fullName" from clients
+        if "fullName" not in values and "name" in values:
+            values["fullName"] = values["name"]
+        return values
 
     class Config:
         allow_population_by_field_name = True

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -77,3 +77,24 @@ def test_signup_and_tracking(tmp_path):
     db.refresh(user)
     assert user.enrichment_count == 1
     db.close()
+
+
+def test_signup_accepts_name_field(tmp_path):
+    app, database, models = setup_app(tmp_path)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "user2@example.com",
+            "password": "secret",
+            "name": "Alt Name",
+            "role": "Marketing",
+        },
+    )
+    assert resp.status_code == 200
+
+    db = database.SessionLocal()
+    user = db.query(models.User).filter_by(email="user2@example.com").first()
+    assert user.full_name == "Alt Name"
+    db.close()


### PR DESCRIPTION
## Summary
- accept `name` as an alias for `fullName` during user signup
- cover signup alias behavior with a new regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896ec38d18c8324a305e24ab6a2ab2e