### PR TITLE
Handle signup without role selection

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,6 @@ from io import StringIO
 from typing import Dict, List, Optional
 from urllib.parse import urlparse
 from datetime import datetime
-from enum import Enum
 
 from fastapi import FastAPI, UploadFile, File, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -47,17 +46,11 @@ def get_config():
     return Settings()
 
 # --- Schemas ---
-class UserRole(str, Enum):
-    SALES = "Sales"
-    MARKETING = "Marketing"
-    DATA_ANALYST = "Data Analyst"
-
-
 class UserSignup(BaseModel):
     email: str
     password: str
     full_name: str = Field(..., alias="fullName")
-    role: UserRole
+    role: Optional[str] = None
 
     @root_validator(pre=True)
     def populate_fullname(cls, values):
@@ -347,7 +340,7 @@ def signup(
         email=credentials.email,
         hashed_password=hashed_password,
         full_name=credentials.full_name,
-        role=credentials.role.value,
+        role=credentials.role or "User",
     )
     db.add(user)
     db.commit()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -98,3 +98,24 @@ def test_signup_accepts_name_field(tmp_path):
     user = db.query(models.User).filter_by(email="user2@example.com").first()
     assert user.full_name == "Alt Name"
     db.close()
+
+
+def test_signup_without_role_defaults(tmp_path):
+    app, database, models = setup_app(tmp_path)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "norole@example.com",
+            "password": "secret",
+            "fullName": "No Role",
+        },
+    )
+    assert resp.status_code == 200
+
+    db = database.SessionLocal()
+    user = db.query(models.User).filter_by(email="norole@example.com").first()
+    assert user.full_name == "No Role"
+    assert user.role == "User"
+    db.close()


### PR DESCRIPTION
## Summary
- Allow API signup requests without a role field by accepting an optional role
- Default missing roles to `"User"`
- Add regression test ensuring signup works when no role is provided

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896efdb1dd48324acf27395d081bd5a