### PR TITLE
Handle missing identifiers in CSV rows

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -401,16 +401,16 @@ async def process(
             mapped_rows.append(mapped_row)
         rows = mapped_rows
 
-    # Require at least a domain OR company name OR LinkedIn URL per row
+    # Filter out rows missing key identifiers rather than failing the request
+    filtered_rows: List[Dict[str, Optional[str]]] = []
     for row in rows:
         has_domain = (row.get("Domain") or "").strip()
         has_name = (row.get("Company Name") or "").strip()
         has_linkedin = (row.get("LinkedIn URL") or "").strip()
         if not (has_domain or has_name or has_linkedin):
-            raise HTTPException(
-                status_code=400,
-                detail="Domain, Company Name, or LinkedIn URL is required",
-            )
+            continue
+        filtered_rows.append(row)
+    rows = filtered_rows
 
     enriched = enrich_domains(rows, db)
     task_id = str(uuid.uuid4())

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,0 +1,53 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from test_auth import setup_app
+
+
+def test_process_skips_rows_missing_identifiers(tmp_path):
+    app, database, _ = setup_app(tmp_path)
+    with database.engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS company_updated (
+                    id INTEGER PRIMARY KEY,
+                    name VARCHAR,
+                    domain VARCHAR UNIQUE,
+                    countries VARCHAR,
+                    hq VARCHAR,
+                    industry VARCHAR,
+                    subindustry VARCHAR,
+                    keywords_cntxt VARCHAR,
+                    size VARCHAR,
+                    linkedin_url VARCHAR
+                )
+                """
+            )
+        )
+
+    client = TestClient(app)
+
+    resp = client.post(
+        "/api/auth/signup",
+        json={"email": "process_user@example.com", "password": "secret", "fullName": "Test"},
+    )
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    data = [
+        {"Domain": "example.com", "Company Name": "Example Co"},
+        {"Domain": "", "Company Name": "", "LinkedIn URL": ""},
+    ]
+
+    resp = client.post("/api/process", json={"data": data}, headers=headers)
+    assert resp.status_code == 200
+    task_id = resp.json()["task_id"]
+
+    resp = client.get("/api/results", params={"task_id": task_id})
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 1
+    assert results[0]["originalData"]["Domain"] == "example.com"
+


### PR DESCRIPTION
## Summary
- Skip processing rows that lack Domain, Company Name, and LinkedIn URL to avoid request failures
- Add regression test ensuring only valid rows are processed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896f2c447a0832486f9584719e58796