### PR TITLE
Fix authentication for data enrichment request

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,9 @@ from datetime import datetime
 
 from fastapi import FastAPI, UploadFile, File, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi_jwt_auth import AuthJWT
+from fastapi_jwt_auth.exceptions import AuthJWTException
 from passlib.context import CryptContext
 from pydantic import BaseModel, Field, root_validator
 from sqlalchemy.orm import Session
@@ -44,6 +46,11 @@ class Settings(BaseModel):
 @AuthJWT.load_config
 def get_config():
     return Settings()
+
+
+@app.exception_handler(AuthJWTException)
+def authjwt_exception_handler(request, exc):
+    return JSONResponse(status_code=exc.status_code, content={"detail": exc.message})
 
 # --- Schemas ---
 class UserSignup(BaseModel):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -105,7 +105,10 @@ export default function App() {
     try {
       const res = await fetch(`${API}/api/process`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(user?.token ? { Authorization: `Bearer ${user.token}` } : {}),
+        },
         body: JSON.stringify({ data: mappedData }),
       });
       if (!res.ok) {


### PR DESCRIPTION
## Summary
- ensure mapped CSV data upload includes bearer auth token
- handle missing auth token errors gracefully

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896f680cf888324880e10bdf024a251