### PR TITLE
fix: default API base url for fetch

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,7 +20,10 @@ import { ChatPanel } from './components/ChatPanel';
 import { ComplianceBanner } from './components/ComplianceBanner';
 import { LandingPage } from './components/LandingPage';
 
-const API = import.meta.env.VITE_API_BASE;
+// Allow the app to work even if VITE_API_BASE isn't configured by falling back
+// to relative URLs. This prevents "Failed to fetch" network errors when the
+// environment variable is missing and the resulting URL would be invalid.
+const API = import.meta.env.VITE_API_BASE || '';
 
 export default function App() {
   const [user, setUser] = useState(null);

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -12,7 +12,9 @@ export function LandingPage({ onSignIn }) {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [isSignup, setIsSignup] = useState(false);
   const [errors, setErrors] = useState({});
-  const API = import.meta.env.VITE_API_BASE;
+  // Use relative URLs if VITE_API_BASE isn't defined so the landing page can
+  // communicate with the backend without throwing a network error.
+  const API = import.meta.env.VITE_API_BASE || '';
 
   const validate = (field, value) => {
     let message = "";

--- a/frontend/src/components/UploadScreen.jsx
+++ b/frontend/src/components/UploadScreen.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
 export function UploadScreen({ onFileUploaded }) {
-  const API = import.meta.env.VITE_API_BASE;
+  // Fallback to relative path when VITE_API_BASE isn't provided to avoid
+  // "Failed to fetch" errors due to an undefined base URL.
+  const API = import.meta.env.VITE_API_BASE || '';
 
   const handleChange = async (e) => {
     const file = e.target.files[0];


### PR DESCRIPTION
## Summary
- avoid `Failed to fetch` errors by defaulting API base URL to relative path when `VITE_API_BASE` is unset

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896fdc216d08324a1389b847a5eb8a6