### PR TITLE
Add Namecheap deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Build & Deploy to Namecheap (public_html)
+
+on:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (Vite)
+        env:
+          CI: 'true'
+        run: npm run build
+
+      - name: FTP Deploy to Namecheap /public_html
+        uses: SamKirkland/FTP-Deploy-Action@v4
+        with:
+          server: ${{ secrets.FTP_SERVER }}          # server902.web-hosting.com
+          username: ${{ secrets.FTP_USERNAME }}      # deploy@bizdetails.xyz
+          password: ${{ secrets.FTP_PASSWORD }}
+          port: ${{ secrets.FTP_PORT }}              # 21
+          protocol: ftp
+          local-dir: dist
+          server-dir: /public_html
+          # Turn this to true AFTER your first successful deploy
+          # (it deletes files on server not present in dist)
+          dangerous-clean-slate: false
+          exclude: |
+            **/.git*
+            **/.DS_Store
+            **/node_modules/**
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the Vite/React app and deploy to Namecheap via FTP

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897601f60b883248b6759f1c5ba395e