### PR TITLE
Add admin CSV import and frontend interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .env
 node_modules/
 frontend/node_modules/
+frontend/dist/
 .pytest_cache/
 pytest_cache/
 *.sqlite3

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BizDetails Admin</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="min-h-screen bg-gray-50">
+    <div id="root"></div>
+    <script type="module" src="/src/admin_main.jsx"></script>
+  </body>
+</html>
+

--- a/frontend/src/AdminApp.jsx
+++ b/frontend/src/AdminApp.jsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+
+// Allow relative URLs if VITE_API_BASE isn't configured
+const API = import.meta.env.VITE_API_BASE || '';
+
+export default function AdminApp() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [token, setToken] = useState(null);
+  const [file, setFile] = useState(null);
+  const [message, setMessage] = useState('');
+
+  const handleLogin = async (e) => {
+    e.preventDefault();
+    setMessage('');
+    try {
+      const res = await fetch(`${API}/api/auth/signin`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setToken(data.access_token);
+      } else {
+        setMessage('Login failed');
+      }
+    } catch (err) {
+      setMessage('Login error');
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!file) return;
+    setMessage('');
+    try {
+      const form = new FormData();
+      form.append('file', file);
+      const res = await fetch(`${API}/api/admin/company-updated/upload`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: form,
+      });
+      if (res.ok) {
+        setMessage('Upload successful');
+        setFile(null);
+      } else {
+        setMessage('Upload failed');
+      }
+    } catch (err) {
+      setMessage('Upload error');
+    }
+  };
+
+  if (!token) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <form onSubmit={handleLogin} className="bg-white p-6 rounded shadow w-80 space-y-4">
+          <h1 className="text-xl font-semibold text-center">Admin Login</h1>
+          <input
+            type="email"
+            placeholder="Email"
+            className="w-full border px-3 py-2 rounded"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            className="w-full border px-3 py-2 rounded"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700"
+          >
+            Sign In
+          </button>
+          {message && <p className="text-red-500 text-sm text-center">{message}</p>}
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="bg-white p-6 rounded shadow w-96 space-y-4 text-center">
+        <h1 className="text-xl font-semibold">Upload Company CSV</h1>
+        <input
+          type="file"
+          accept=".csv"
+          onChange={(e) => setFile(e.target.files[0])}
+          className="w-full"
+        />
+        <button
+          onClick={handleUpload}
+          className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+          disabled={!file}
+        >
+          Upload
+        </button>
+        {message && <p className="text-sm text-center">{message}</p>}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/admin_main.jsx
+++ b/frontend/src/admin_main.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import AdminApp from './AdminApp';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<AdminApp />);
+


### PR DESCRIPTION
## Summary
- add admin-only CSV upload endpoint to upsert `company_updated` records
- create dedicated admin frontend with login and CSV uploader
- ignore built frontend assets in version control

## Testing
- `npm test --prefix frontend`
- `npm run build --prefix frontend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68973fb05eb883249567f12f6559e91a