### PR TITLE
Fix FTP deployment workflow local directory path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,8 @@ jobs:
           password: ${{ secrets.FTP_PASSWORD }}
           port: ${{ secrets.FTP_PORT }}           # 21
           protocol: ftp
-          local-dir: frontend/dist
+          # local-dir must end with a trailing slash for FTP-Deploy-Action
+          local-dir: frontend/dist/
           server-dir: /public_html
           dangerous-clean-slate: false
           exclude: |


### PR DESCRIPTION
## Summary
- ensure FTP-Deploy local directory ends with slash to satisfy action requirements

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689765fbeedc83249246898d5da653c5