### PR TITLE
Add missing company name columns

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -20,29 +20,47 @@ def get_db():
 
 
 def init_db():
-    """Ensure required columns exist in the users table."""
+    """Ensure required columns exist in the database tables."""
     inspector = inspect(engine)
-    if "users" not in inspector.get_table_names():
-        return
-
-    existing_columns = {col["name"] for col in inspector.get_columns("users")}
+    table_names = inspector.get_table_names()
 
     with engine.begin() as conn:
-        if "full_name" not in existing_columns:
-            conn.execute(text("ALTER TABLE users ADD COLUMN full_name VARCHAR"))
-        if "role" not in existing_columns:
-            conn.execute(text("ALTER TABLE users ADD COLUMN role VARCHAR"))
-        if "enrichment_count" not in existing_columns:
-            conn.execute(
-                text(
-                    "ALTER TABLE users ADD COLUMN enrichment_count INTEGER NOT NULL DEFAULT 0"
+        if "users" in table_names:
+            user_columns = {col["name"] for col in inspector.get_columns("users")}
+
+            if "full_name" not in user_columns:
+                conn.execute(text("ALTER TABLE users ADD COLUMN full_name VARCHAR"))
+            if "role" not in user_columns:
+                conn.execute(text("ALTER TABLE users ADD COLUMN role VARCHAR"))
+            if "enrichment_count" not in user_columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE users ADD COLUMN enrichment_count INTEGER NOT NULL DEFAULT 0"
+                    )
                 )
-            )
-        if "last_login" not in existing_columns:
-            conn.execute(text("ALTER TABLE users ADD COLUMN last_login TIMESTAMP"))
-        if "account_status" not in existing_columns:
-            conn.execute(
-                text(
-                    "ALTER TABLE users ADD COLUMN account_status VARCHAR NOT NULL DEFAULT 'Active'"
+            if "last_login" not in user_columns:
+                conn.execute(text("ALTER TABLE users ADD COLUMN last_login TIMESTAMP"))
+            if "account_status" not in user_columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE users ADD COLUMN account_status VARCHAR NOT NULL DEFAULT 'Active'"
+                    )
                 )
-            )
+
+        if "company_updated" in table_names:
+            company_columns = {
+                col["name"] for col in inspector.get_columns("company_updated")
+            }
+
+            if "original_name" not in company_columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE company_updated ADD COLUMN original_name VARCHAR"
+                    )
+                )
+            if "legal_name" not in company_columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE company_updated ADD COLUMN legal_name VARCHAR"
+                    )
+                )

--- a/backend/migrations/add_original_and_legal_name_columns.sql
+++ b/backend/migrations/add_original_and_legal_name_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE company_updated ADD COLUMN IF NOT EXISTS original_name VARCHAR;
+ALTER TABLE company_updated ADD COLUMN IF NOT EXISTS legal_name VARCHAR;


### PR DESCRIPTION
## Summary
- ensure `init_db` adds `original_name` and `legal_name` columns to `company_updated`
- provide SQL migration script for adding missing columns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68978df83bd0832495a2beaf7158bf2f