### PR TITLE
Add futuristic dashboard and CSV enrichment UI

### DIFF
--- a/frontend/src/components/CompanyDetailsPanel.jsx
+++ b/frontend/src/components/CompanyDetailsPanel.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+export function CompanyDetailsPanel({ company, onClose }) {
+  return (
+    <div
+      className={`fixed top-0 right-0 h-full w-80 bg-gray-900 text-green-400 shadow-lg transform transition-transform duration-300 border-l border-green-500 ${
+        company ? 'translate-x-0' : 'translate-x-full'
+      }`}
+    >
+      <div className="p-4 border-b border-green-500 flex justify-between items-center">
+        <h2 className="text-lg">Details</h2>
+        <button
+          onClick={onClose}
+          className="text-green-400 hover:text-green-200"
+        >
+          ✕
+        </button>
+      </div>
+      {company && (
+        <div className="p-4 space-y-2 text-sm">
+          <p>
+            <strong>Name:</strong> {company.name || 'N/A'}
+          </p>
+          <p>
+            <strong>Domain:</strong> {company.domain}
+          </p>
+          <p>
+            <strong>Headquarters:</strong> {company.hq || 'N/A'}
+          </p>
+          <p>
+            <strong>Industry:</strong> {company.industry || 'N/A'}
+          </p>
+          <p>
+            <strong>LinkedIn:</strong>{' '}
+            {company.linkedin_url ? (
+              <a
+                href={company.linkedin_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 hover:underline"
+              >
+                {company.linkedin_url}
+              </a>
+            ) : (
+              'N/A'
+            )}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/CompanyTable.jsx
+++ b/frontend/src/components/CompanyTable.jsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { CompanyDetailsPanel } from './CompanyDetailsPanel';
+
+const API = import.meta.env.VITE_API_BASE || '';
+
+export function CompanyTable() {
+  const [companies, setCompanies] = useState([]);
+  const [search, setSearch] = useState('');
+  const [sortConfig, setSortConfig] = useState({ key: 'name', direction: 'asc' });
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    fetch(`${API}/api/company_updated`)
+      .then((res) => res.json())
+      .then((data) => setCompanies(data.companies || []));
+  }, []);
+
+  const handleSort = (key) => {
+    let direction = 'asc';
+    if (sortConfig.key === key && sortConfig.direction === 'asc') {
+      direction = 'desc';
+    }
+    setSortConfig({ key, direction });
+  };
+
+  const sorted = [...companies].sort((a, b) => {
+    const valA = a[sortConfig.key] || '';
+    const valB = b[sortConfig.key] || '';
+    if (valA < valB) return sortConfig.direction === 'asc' ? -1 : 1;
+    if (valA > valB) return sortConfig.direction === 'asc' ? 1 : -1;
+    return 0;
+  });
+
+  const filtered = sorted.filter((c) => {
+    const term = search.toLowerCase();
+    return (
+      (c.name || '').toLowerCase().includes(term) ||
+      (c.domain || '').toLowerCase().includes(term) ||
+      (c.industry || '').toLowerCase().includes(term) ||
+      (c.hq || '').toLowerCase().includes(term)
+    );
+  });
+
+  return (
+    <div className="relative text-green-400 font-mono">
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search..."
+        className="mb-4 w-full bg-gray-900 border border-green-500 rounded px-3 py-2 placeholder-green-700 focus:outline-none"
+      />
+      <div className="overflow-x-auto">
+        <table className="min-w-full border border-green-500">
+          <thead className="bg-gray-900">
+            <tr>
+              <th
+                className="px-4 py-2 border border-green-500 cursor-pointer"
+                onClick={() => handleSort('name')}
+              >
+                Company Name
+              </th>
+              <th
+                className="px-4 py-2 border border-green-500 cursor-pointer"
+                onClick={() => handleSort('domain')}
+              >
+                Domain
+              </th>
+              <th
+                className="px-4 py-2 border border-green-500 cursor-pointer"
+                onClick={() => handleSort('hq')}
+              >
+                Headquarters
+              </th>
+              <th
+                className="px-4 py-2 border border-green-500 cursor-pointer"
+                onClick={() => handleSort('industry')}
+              >
+                Industry
+              </th>
+              <th className="px-4 py-2 border border-green-500">LinkedIn</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((c) => (
+              <tr
+                key={c.id}
+                className="hover:bg-gray-800 transition-colors cursor-pointer"
+                onClick={() => setSelected(c)}
+              >
+                <td className="px-4 py-2 border border-green-500">{c.name || 'N/A'}</td>
+                <td className="px-4 py-2 border border-green-500">{c.domain}</td>
+                <td className="px-4 py-2 border border-green-500">{c.hq || 'N/A'}</td>
+                <td className="px-4 py-2 border border-green-500">{c.industry || 'N/A'}</td>
+                <td className="px-4 py-2 border border-green-500 text-center">
+                  {c.linkedin_url ? (
+                    <a
+                      href={c.linkedin_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-400 hover:underline"
+                    >
+                      Link
+                    </a>
+                  ) : (
+                    'N/A'
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <CompanyDetailsPanel company={selected} onClose={() => setSelected(null)} />
+    </div>
+  );
+}

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,4 +1,10 @@
 import React from 'react';
+import { CompanyTable } from './CompanyTable';
+
 export function Dashboard() {
-  return <p>Dashboard placeholder.</p>;
+  return (
+    <div className="bg-black p-4 rounded border border-green-500">
+      <CompanyTable />
+    </div>
+  );
 }

--- a/frontend/src/components/ResultsView.jsx
+++ b/frontend/src/components/ResultsView.jsx
@@ -1,34 +1,87 @@
 import React from 'react';
 
+const API = import.meta.env.VITE_API_BASE || '';
+
 export function ResultsView({ results }) {
   if (!results) {
     return <p>No results available.</p>;
   }
 
+  const downloadCSV = () => {
+    const headers = [
+      'Company Name',
+      'Website',
+      'Headquarters',
+      'Industry',
+      'Employee Size',
+      'Company LinkedIn',
+    ];
+    const rows = results.map((r) => [
+      r.companyName,
+      r.domain,
+      r.hq || 'N/A',
+      r.industry || 'N/A',
+      r.size || 'N/A',
+      r.linkedin_url || 'N/A',
+    ]);
+    const csv = [headers.join(','), ...rows.map((row) => row.join(','))].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'enriched.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const saveResults = async () => {
+    await fetch(`${API}/api/save_results`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ results }),
+    });
+  };
+
   return (
-    <table className="min-w-full text-left border">
-      <thead>
-        <tr>
-          <th className="border px-2">Company Name</th>
-          <th className="border px-2">Website</th>
-          <th className="border px-2">Headquarters</th>
-          <th className="border px-2">Industry</th>
-          <th className="border px-2">Employee Size</th>
-          <th className="border px-2">Company LinkedIn</th>
-        </tr>
-      </thead>
-      <tbody>
-        {results.map((r) => (
-          <tr key={r.id}>
-            <td className="border px-2">{r.companyName}</td>
-            <td className="border px-2">{r.domain}</td>
-            <td className="border px-2">{r.hq}</td>
-            <td className="border px-2">{r.industry}</td>
-            <td className="border px-2">{r.size}</td>
-            <td className="border px-2">{r.linkedin_url}</td>
+    <div className="text-green-400 font-mono">
+      <div className="flex gap-4 mb-4">
+        <button
+          onClick={downloadCSV}
+          className="px-4 py-2 bg-gray-900 border border-green-500 rounded hover:bg-gray-800"
+        >
+          Download Enriched CSV
+        </button>
+        <button
+          onClick={saveResults}
+          className="px-4 py-2 bg-gray-900 border border-green-500 rounded hover:bg-gray-800"
+        >
+          Save to My List
+        </button>
+      </div>
+      <table className="min-w-full text-left border border-green-500">
+        <thead className="bg-gray-900">
+          <tr>
+            <th className="border border-green-500 px-2">Company Name</th>
+            <th className="border border-green-500 px-2">Website</th>
+            <th className="border border-green-500 px-2">Headquarters</th>
+            <th className="border border-green-500 px-2">Industry</th>
+            <th className="border border-green-500 px-2">Employee Size</th>
+            <th className="border border-green-500 px-2">Company LinkedIn</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {results.map((r) => (
+            <tr key={r.id} className="hover:bg-gray-800">
+              <td className="border border-green-500 px-2">{r.companyName}</td>
+              <td className="border border-green-500 px-2">{r.domain}</td>
+              <td className="border border-green-500 px-2">{r.hq || 'N/A'}</td>
+              <td className="border border-green-500 px-2">{r.industry || 'N/A'}</td>
+              <td className="border border-green-500 px-2">{r.size || 'N/A'}</td>
+              <td className="border border-green-500 px-2">{r.linkedin_url || 'N/A'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add API to list `company_updated` records and save enrichment results
- implement dark-themed dashboard with searchable, sortable company table and details panel
- enhance CSV upload and results views with progress bar, download and save actions

## Testing
- `pytest`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897a1e53b948324a77ee586a9956165