### PR TITLE
Reorder primary tabs and default to Company Data

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,35 +1,34 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
   Upload,
   Database,
   MessageCircle,
-  BarChart3,
   FileText,
   Settings,
   User,
   LogOut,
-} from 'lucide-react';
-import { Button } from './components/ui/button';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
-import { Badge } from './components/ui/badge';
-import { UploadScreen } from './components/UploadScreen';
-import { ColumnMappingScreen } from './components/ColumnMappingScreen';
-import { ResultsView } from './components/ResultsView';
-import { Dashboard } from './components/Dashboard';
-import { ChatPanel } from './components/ChatPanel';
-import { ComplianceBanner } from './components/ComplianceBanner';
-import { LandingPage } from './components/LandingPage';
+} from "lucide-react";
+import { Button } from "./components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/ui/tabs";
+import { Badge } from "./components/ui/badge";
+import { UploadScreen } from "./components/UploadScreen";
+import { ColumnMappingScreen } from "./components/ColumnMappingScreen";
+import { ResultsView } from "./components/ResultsView";
+import { Dashboard } from "./components/Dashboard";
+import { ChatPanel } from "./components/ChatPanel";
+import { ComplianceBanner } from "./components/ComplianceBanner";
+import { LandingPage } from "./components/LandingPage";
 
 // Allow the app to work even if VITE_API_BASE isn't configured by falling back
 // to relative URLs. This prevents "Failed to fetch" network errors when the
 // environment variable is missing and the resulting URL would be invalid.
-const API = import.meta.env.VITE_API_BASE || '';
+const API = import.meta.env.VITE_API_BASE || "";
 
 export default function App() {
   const [user, setUser] = useState(null);
   const [authChecking, setAuthChecking] = useState(true);
-  const [activeTab, setActiveTab] = useState('upload');
-  const [uploadStep, setUploadStep] = useState('upload');
+  const [activeTab, setActiveTab] = useState("dashboard");
+  const [uploadStep, setUploadStep] = useState("upload");
   const [showChat, setShowChat] = useState(false);
   const [showCompliance, setShowCompliance] = useState(true);
   const [uploadedFile, setUploadedFile] = useState(null);
@@ -38,7 +37,7 @@ export default function App() {
 
   const isTokenExpired = (token) => {
     try {
-      const payload = JSON.parse(atob(token.split('.')[1]));
+      const payload = JSON.parse(atob(token.split(".")[1]));
       return payload.exp ? payload.exp * 1000 < Date.now() : false;
     } catch {
       return true;
@@ -46,7 +45,7 @@ export default function App() {
   };
 
   useEffect(() => {
-    const storedUser = localStorage.getItem('user');
+    const storedUser = localStorage.getItem("user");
     if (storedUser) {
       const parsed = JSON.parse(storedUser);
       if (!isTokenExpired(parsed.token)) {
@@ -56,22 +55,22 @@ export default function App() {
           .then((res) => {
             if (res.ok) {
               setUser(parsed);
-              const savedTab = localStorage.getItem('activeTab');
+              const savedTab = localStorage.getItem("activeTab");
               if (savedTab) setActiveTab(savedTab);
             } else {
-              localStorage.removeItem('user');
-              localStorage.removeItem('activeTab');
+              localStorage.removeItem("user");
+              localStorage.removeItem("activeTab");
             }
           })
           .catch(() => {
-            localStorage.removeItem('user');
-            localStorage.removeItem('activeTab');
+            localStorage.removeItem("user");
+            localStorage.removeItem("activeTab");
           })
           .finally(() => setAuthChecking(false));
         return;
       } else {
-        localStorage.removeItem('user');
-        localStorage.removeItem('activeTab');
+        localStorage.removeItem("user");
+        localStorage.removeItem("activeTab");
       }
     }
     setAuthChecking(false);
@@ -79,45 +78,45 @@ export default function App() {
 
   useEffect(() => {
     if (user) {
-      localStorage.setItem('activeTab', activeTab);
+      localStorage.setItem("activeTab", activeTab);
     }
   }, [activeTab, user]);
 
   const handleSignIn = ({ email, name, token }) => {
     const newUser = { email, name, token };
     setUser(newUser);
-    localStorage.setItem('user', JSON.stringify(newUser));
+    localStorage.setItem("user", JSON.stringify(newUser));
   };
 
   const handleSignOut = () => {
     setUser(null);
-    setActiveTab('upload');
-    setUploadStep('upload');
+    setActiveTab("dashboard");
+    setUploadStep("upload");
     setUploadedFile(null);
     setProcessedResults(null);
-    localStorage.removeItem('user');
-    localStorage.removeItem('activeTab');
+    localStorage.removeItem("user");
+    localStorage.removeItem("activeTab");
   };
 
   const handleFileUploaded = (fileData) => {
     setUploadedFile(fileData);
-    setUploadStep('mapping');
+    setUploadStep("mapping");
   };
 
   const handleColumnMappingComplete = async (mappedData) => {
-    setUploadStep('processing');
+    setUploadStep("processing");
     setProgress(0);
     try {
       const res = await fetch(`${API}/api/process`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
           ...(user?.token ? { Authorization: `Bearer ${user.token}` } : {}),
         },
         body: JSON.stringify({ data: mappedData }),
       });
       if (!res.ok) {
-        throw new Error('Failed to process data');
+        throw new Error("Failed to process data");
       }
       const { task_id } = await res.json();
       let done = false;
@@ -125,17 +124,17 @@ export default function App() {
         setProgress((p) => (p < 90 ? p + 10 : p));
         const statusRes = await fetch(`${API}/api/results/${task_id}/status`);
         const { status } = await statusRes.json();
-        if (status === 'completed') {
+        if (status === "completed") {
           clearInterval(interval);
           setProgress(100);
           const res2 = await fetch(`${API}/api/results?task_id=${task_id}`);
           if (!res2.ok) {
-            throw new Error('Failed to fetch results');
+            throw new Error("Failed to fetch results");
           }
           const { results } = await res2.json();
           setProcessedResults(results);
-          setActiveTab('results');
-          setUploadStep('upload');
+          setActiveTab("results");
+          setUploadStep("upload");
           done = true;
         }
       }, 500);
@@ -148,19 +147,19 @@ export default function App() {
       }, 10000);
     } catch (err) {
       console.error(err);
-      alert(err.message || 'An error occurred while processing your data.');
-      setUploadStep('mapping');
+      alert(err.message || "An error occurred while processing your data.");
+      setUploadStep("mapping");
     }
   };
 
   const handleBackToUpload = () => {
-    setUploadStep('upload');
+    setUploadStep("upload");
     setUploadedFile(null);
   };
 
   const getUploadTabContent = () => {
     switch (uploadStep) {
-      case 'mapping':
+      case "mapping":
         return (
           <ColumnMappingScreen
             uploadedFile={uploadedFile}
@@ -168,7 +167,7 @@ export default function App() {
             onBack={handleBackToUpload}
           />
         );
-      case 'processing':
+      case "processing":
         return (
           <div className="flex flex-col items-center justify-center py-24 space-y-4">
             <div className="w-64 bg-gray-800 h-2 rounded">
@@ -199,7 +198,9 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-black text-green-400 font-mono">
-      {showCompliance && <ComplianceBanner onDismiss={() => setShowCompliance(false)} />}
+      {showCompliance && (
+        <ComplianceBanner onDismiss={() => setShowCompliance(false)} />
+      )}
       <header className="bg-gray-900 border-b border-green-500 shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
@@ -241,31 +242,49 @@ export default function App() {
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex gap-6">
-          <div className={`flex-1 transition-all duration-300 ${showChat ? 'mr-80' : ''}`}>
-            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+          <div
+            className={`flex-1 transition-all duration-300 ${showChat ? "mr-80" : ""}`}
+          >
+            <Tabs
+              value={activeTab}
+              onValueChange={setActiveTab}
+              className="w-full"
+            >
               <TabsList className="grid w-full grid-cols-3 mb-8">
-                <TabsTrigger value="upload" className="flex items-center gap-2">
-                  {uploadStep === 'mapping' ? <Settings className="w-4 h-4" /> : <Upload className="w-4 h-4" />} 
-                  {uploadStep === 'mapping' ? 'Column Mapping' : 'Data Enrichment (CSV Upload)'}
+                <TabsTrigger
+                  value="dashboard"
+                  className="flex items-center gap-2"
+                >
+                  <Database className="w-4 h-4" />
+                  Company Data
                 </TabsTrigger>
-                <TabsTrigger value="results" className="flex items-center gap-2">
+                <TabsTrigger value="upload" className="flex items-center gap-2">
+                  {uploadStep === "mapping" ? (
+                    <Settings className="w-4 h-4" />
+                  ) : (
+                    <Upload className="w-4 h-4" />
+                  )}
+                  {uploadStep === "mapping"
+                    ? "Column Mapping"
+                    : "Data Enrichment (CSV Upload)"}
+                </TabsTrigger>
+                <TabsTrigger
+                  value="results"
+                  className="flex items-center gap-2"
+                >
                   <FileText className="w-4 h-4" />
                   Results
                 </TabsTrigger>
-                <TabsTrigger value="dashboard" className="flex items-center gap-2">
-                  <BarChart3 className="w-4 h-4" />
-                  Dashboard
-                </TabsTrigger>
               </TabsList>
 
+              <TabsContent value="dashboard" className="space-y-6">
+                <Dashboard />
+              </TabsContent>
               <TabsContent value="upload" className="space-y-6">
                 {getUploadTabContent()}
               </TabsContent>
               <TabsContent value="results" className="space-y-6">
                 <ResultsView results={processedResults} />
-              </TabsContent>
-              <TabsContent value="dashboard" className="space-y-6">
-                <Dashboard />
               </TabsContent>
             </Tabs>
           </div>


### PR DESCRIPTION
## Summary
- Default users to the Company Data view on login and sign-out
- Rename Dashboard tab to "Company Data" and move it to the first position
- Shift Data Enrichment and Results tabs to second and third positions respectively

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897a74cf8a08324b004f81141901310