### PR TITLE
feat: open LinkedIn links in new tab

### DIFF
--- a/frontend/src/components/CompanyTable.jsx
+++ b/frontend/src/components/CompanyTable.jsx
@@ -1,12 +1,15 @@
-import React, { useEffect, useState } from 'react';
-import { CompanyDetailsPanel } from './CompanyDetailsPanel';
+import React, { useEffect, useState } from "react";
+import { CompanyDetailsPanel } from "./CompanyDetailsPanel";
 
-const API = import.meta.env.VITE_API_BASE || '';
+const API = import.meta.env.VITE_API_BASE || "";
 
 export function CompanyTable() {
   const [companies, setCompanies] = useState([]);
-  const [search, setSearch] = useState('');
-  const [sortConfig, setSortConfig] = useState({ key: 'name', direction: 'asc' });
+  const [search, setSearch] = useState("");
+  const [sortConfig, setSortConfig] = useState({
+    key: "name",
+    direction: "asc",
+  });
   const [selected, setSelected] = useState(null);
 
   useEffect(() => {
@@ -16,28 +19,28 @@ export function CompanyTable() {
   }, []);
 
   const handleSort = (key) => {
-    let direction = 'asc';
-    if (sortConfig.key === key && sortConfig.direction === 'asc') {
-      direction = 'desc';
+    let direction = "asc";
+    if (sortConfig.key === key && sortConfig.direction === "asc") {
+      direction = "desc";
     }
     setSortConfig({ key, direction });
   };
 
   const sorted = [...companies].sort((a, b) => {
-    const valA = a[sortConfig.key] || '';
-    const valB = b[sortConfig.key] || '';
-    if (valA < valB) return sortConfig.direction === 'asc' ? -1 : 1;
-    if (valA > valB) return sortConfig.direction === 'asc' ? 1 : -1;
+    const valA = a[sortConfig.key] || "";
+    const valB = b[sortConfig.key] || "";
+    if (valA < valB) return sortConfig.direction === "asc" ? -1 : 1;
+    if (valA > valB) return sortConfig.direction === "asc" ? 1 : -1;
     return 0;
   });
 
   const filtered = sorted.filter((c) => {
     const term = search.toLowerCase();
     return (
-      (c.name || '').toLowerCase().includes(term) ||
-      (c.domain || '').toLowerCase().includes(term) ||
-      (c.industry || '').toLowerCase().includes(term) ||
-      (c.hq || '').toLowerCase().includes(term)
+      (c.name || "").toLowerCase().includes(term) ||
+      (c.domain || "").toLowerCase().includes(term) ||
+      (c.industry || "").toLowerCase().includes(term) ||
+      (c.hq || "").toLowerCase().includes(term)
     );
   });
 
@@ -56,25 +59,25 @@ export function CompanyTable() {
             <tr>
               <th
                 className="px-4 py-2 border border-green-500 cursor-pointer"
-                onClick={() => handleSort('name')}
+                onClick={() => handleSort("name")}
               >
                 Company Name
               </th>
               <th
                 className="px-4 py-2 border border-green-500 cursor-pointer"
-                onClick={() => handleSort('domain')}
+                onClick={() => handleSort("domain")}
               >
                 Domain
               </th>
               <th
                 className="px-4 py-2 border border-green-500 cursor-pointer"
-                onClick={() => handleSort('hq')}
+                onClick={() => handleSort("hq")}
               >
                 Headquarters
               </th>
               <th
                 className="px-4 py-2 border border-green-500 cursor-pointer"
-                onClick={() => handleSort('industry')}
+                onClick={() => handleSort("industry")}
               >
                 Industry
               </th>
@@ -88,22 +91,31 @@ export function CompanyTable() {
                 className="hover:bg-gray-800 transition-colors cursor-pointer"
                 onClick={() => setSelected(c)}
               >
-                <td className="px-4 py-2 border border-green-500">{c.name || 'N/A'}</td>
-                <td className="px-4 py-2 border border-green-500">{c.domain}</td>
-                <td className="px-4 py-2 border border-green-500">{c.hq || 'N/A'}</td>
-                <td className="px-4 py-2 border border-green-500">{c.industry || 'N/A'}</td>
+                <td className="px-4 py-2 border border-green-500">
+                  {c.name || "N/A"}
+                </td>
+                <td className="px-4 py-2 border border-green-500">
+                  {c.domain}
+                </td>
+                <td className="px-4 py-2 border border-green-500">
+                  {c.hq || "N/A"}
+                </td>
+                <td className="px-4 py-2 border border-green-500">
+                  {c.industry || "N/A"}
+                </td>
                 <td className="px-4 py-2 border border-green-500 text-center">
                   {c.linkedin_url ? (
                     <a
                       href={c.linkedin_url}
                       target="_blank"
                       rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
                       className="text-blue-400 hover:underline"
                     >
                       Link
                     </a>
                   ) : (
-                    'N/A'
+                    "N/A"
                   )}
                 </td>
               </tr>
@@ -111,7 +123,10 @@ export function CompanyTable() {
           </tbody>
         </table>
       </div>
-      <CompanyDetailsPanel company={selected} onClose={() => setSelected(null)} />
+      <CompanyDetailsPanel
+        company={selected}
+        onClose={() => setSelected(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/ResultsView.jsx
+++ b/frontend/src/components/ResultsView.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React from "react";
 
-const API = import.meta.env.VITE_API_BASE || '';
+const API = import.meta.env.VITE_API_BASE || "";
 
 export function ResultsView({ results }) {
   if (!results) {
@@ -9,35 +9,37 @@ export function ResultsView({ results }) {
 
   const downloadCSV = () => {
     const headers = [
-      'Company Name',
-      'Website',
-      'Headquarters',
-      'Industry',
-      'Employee Size',
-      'Company LinkedIn',
+      "Company Name",
+      "Website",
+      "Headquarters",
+      "Industry",
+      "Employee Size",
+      "Company LinkedIn",
     ];
     const rows = results.map((r) => [
       r.companyName,
       r.domain,
-      r.hq || 'N/A',
-      r.industry || 'N/A',
-      r.size || 'N/A',
-      r.linkedin_url || 'N/A',
+      r.hq || "N/A",
+      r.industry || "N/A",
+      r.size || "N/A",
+      r.linkedin_url || "N/A",
     ]);
-    const csv = [headers.join(','), ...rows.map((row) => row.join(','))].join('\n');
-    const blob = new Blob([csv], { type: 'text/csv' });
+    const csv = [headers.join(","), ...rows.map((row) => row.join(","))].join(
+      "\n",
+    );
+    const blob = new Blob([csv], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
-    a.download = 'enriched.csv';
+    a.download = "enriched.csv";
     a.click();
     URL.revokeObjectURL(url);
   };
 
   const saveResults = async () => {
     await fetch(`${API}/api/save_results`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ results }),
     });
   };
@@ -74,10 +76,27 @@ export function ResultsView({ results }) {
             <tr key={r.id} className="hover:bg-gray-800">
               <td className="border border-green-500 px-2">{r.companyName}</td>
               <td className="border border-green-500 px-2">{r.domain}</td>
-              <td className="border border-green-500 px-2">{r.hq || 'N/A'}</td>
-              <td className="border border-green-500 px-2">{r.industry || 'N/A'}</td>
-              <td className="border border-green-500 px-2">{r.size || 'N/A'}</td>
-              <td className="border border-green-500 px-2">{r.linkedin_url || 'N/A'}</td>
+              <td className="border border-green-500 px-2">{r.hq || "N/A"}</td>
+              <td className="border border-green-500 px-2">
+                {r.industry || "N/A"}
+              </td>
+              <td className="border border-green-500 px-2">
+                {r.size || "N/A"}
+              </td>
+              <td className="border border-green-500 px-2">
+                {r.linkedin_url ? (
+                  <a
+                    href={r.linkedin_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-400 hover:underline"
+                  >
+                    Link
+                  </a>
+                ) : (
+                  "N/A"
+                )}
+              </td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- ensure LinkedIn link clicks in Company Data table open new tab without triggering row selection
- make Company LinkedIn values in results view clickable links that open in a new tab

## Testing
- `npm test --prefix frontend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897aac8252c8324860f8352b509a790