### PR TITLE
feat: improve responsive layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#ffffff" />
     <title>BizDetails AI</title>
     <meta
       name="description"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -241,16 +241,14 @@ export default function App() {
       </header>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="flex gap-6">
-          <div
-            className={`flex-1 transition-all duration-300 ${showChat ? "mr-80" : ""}`}
-          >
+        <div className="flex flex-col lg:flex-row gap-6">
+          <div className="flex-1 transition-all duration-300">
             <Tabs
               value={activeTab}
               onValueChange={setActiveTab}
               className="w-full"
             >
-              <TabsList className="grid w-full grid-cols-3 mb-8">
+              <TabsList className="grid w-full grid-cols-1 sm:grid-cols-3 mb-8">
                 <TabsTrigger
                   value="dashboard"
                   className="flex items-center gap-2"
@@ -290,7 +288,7 @@ export default function App() {
           </div>
 
           {showChat && (
-            <div className="fixed right-6 top-24 bottom-6 w-80">
+            <div className="fixed inset-0 w-full z-50 sm:inset-auto sm:right-6 sm:top-24 sm:bottom-6 sm:w-80">
               <ChatPanel onClose={() => setShowChat(false)} />
             </div>
           )}

--- a/frontend/src/components/ChatPanel.jsx
+++ b/frontend/src/components/ChatPanel.jsx
@@ -5,7 +5,7 @@ export function ChatPanel({ onClose }) {
   const [message, setMessage] = useState('');
 
   return (
-    <div className="bg-white border rounded h-full flex flex-col">
+    <div className="bg-white border h-full w-full flex flex-col rounded-none sm:rounded">
       <div className="flex justify-between items-center p-2 border-b">
         <span className="font-semibold">AI Assistant</span>
         <Button onClick={onClose}>Close</Button>


### PR DESCRIPTION
## Summary
- enhance meta tags for mobile support and theme color
- adjust layout and chat panel to be responsive across screen sizes
- tidy chat panel styles for full-width on small devices

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a059a72140832499db3f20b804df29