### PR TITLE
Add dynamic domain filtering and employee size column

### DIFF
--- a/frontend/src/components/CompanyTable.jsx
+++ b/frontend/src/components/CompanyTable.jsx
@@ -131,6 +131,12 @@ export function CompanyTable({ filters = {} }) {
               </th>
               <th
                 className="px-4 py-2 border border-green-500 cursor-pointer"
+                onClick={() => handleSort("size")}
+              >
+                Employees
+              </th>
+              <th
+                className="px-4 py-2 border border-green-500 cursor-pointer"
                 onClick={() => handleSort("industry")}
               >
                 Industry
@@ -153,6 +159,9 @@ export function CompanyTable({ filters = {} }) {
                 </td>
                 <td className="px-4 py-2 border border-green-500">
                   {c.hq || "N/A"}
+                </td>
+                <td className="px-4 py-2 border border-green-500">
+                  {c.size || "N/A"}
                 </td>
                 <td className="px-4 py-2 border border-green-500">
                   {c.industry || "N/A"}

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,42 @@
+from sqlalchemy import text
+from fastapi.testclient import TestClient
+
+from test_auth import setup_app
+from test_admin_upload import _create_company_table
+
+
+def _seed(db):
+    with db.engine.begin() as conn:
+        conn.execute(text("DELETE FROM company_updated"))
+        data = [
+            {"n": "Google", "d": "google.com", "s": "100000"},
+            {"n": "Startup", "d": "startup.io", "s": "8"},
+            {"n": "MidCorp", "d": "midcorp.net", "s": "300"},
+        ]
+        for row in data:
+            conn.execute(
+                text("INSERT INTO company_updated (name, domain, size) VALUES (:n, :d, :s)"),
+                row,
+            )
+
+
+def test_domain_and_size_filters(tmp_path):
+    app, database, _ = setup_app(tmp_path)
+    _create_company_table(database.engine)
+    _seed(database)
+    client = TestClient(app)
+
+    resp = client.get("/api/company_updated", params={"domain": "google.com"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["companies"][0]["domain"] == "google.com"
+
+    resp = client.get(
+        "/api/company_updated",
+        params={"size_range": "1-10"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["companies"][0]["domain"] == "startup.io"


### PR DESCRIPTION
## Summary
- Suggest company domains in filter panel and auto-apply company/domain filters
- Support domain, HQ and employee-size filtering on the backend and expose size field
- Show employee size column in results table and test filter functionality

## Testing
- `cd frontend && npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2cae23a588324927fb946a5795e09