### PR TITLE
Add DeepSeek API fallback for company queries

### DIFF
--- a/backend/app/deepseek.py
+++ b/backend/app/deepseek.py
@@ -1,0 +1,34 @@
+import os
+from typing import Dict
+
+import httpx
+
+DEEPSEEK_URL = "https://api.deepseek.com/company"
+
+class DeepSeekError(Exception):
+    """Raised when the DeepSeek API cannot provide data."""
+
+
+def fetch_company_data(query: str) -> Dict:
+    """Fetch company data from the DeepSeek API for the given query.
+
+    Parameters
+    ----------
+    query: str
+        The company domain or name to search for.
+    """
+    headers = {}
+    api_key = os.getenv("DEEPSEEK_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        resp = httpx.get(
+            DEEPSEEK_URL, params={"query": query}, headers=headers, timeout=10
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if not isinstance(data, dict):
+            raise DeepSeekError("Invalid response from DeepSeek API")
+        return data
+    except Exception as exc:  # broad to wrap httpx/network errors
+        raise DeepSeekError(str(exc)) from exc

--- a/tests/test_deepseek_fallback.py
+++ b/tests/test_deepseek_fallback.py
@@ -1,0 +1,56 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from test_auth import setup_app
+from test_admin_upload import _create_company_table
+
+
+def test_get_company_uses_db_when_present(tmp_path, monkeypatch):
+    app, database, _ = setup_app(tmp_path)
+    import backend.app.main as main
+    _create_company_table(database.engine)
+    with database.engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO company_updated (name, domain) VALUES ('Existing', 'exist.com')")
+        )
+
+    def fail_fetch(query: str):
+        raise AssertionError("API should not be called")
+
+    monkeypatch.setattr(main, "fetch_company_data", fail_fetch)
+
+    client = TestClient(app)
+    resp = client.get("/api/company", params={"domain": "exist.com"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Existing"
+
+
+def test_get_company_falls_back_to_api(tmp_path, monkeypatch):
+    app, database, _ = setup_app(tmp_path)
+    import backend.app.main as main
+    _create_company_table(database.engine)
+
+    def fake_fetch(query: str):
+        return {
+            "name": "Deep Co",
+            "domain": query,
+            "hq": "HQ",
+            "size": "10",
+            "industry": "Tech",
+            "linkedin_url": "https://linkedin.com/company/deepco",
+        }
+
+    monkeypatch.setattr(main, "fetch_company_data", fake_fetch)
+
+    client = TestClient(app)
+    resp = client.get("/api/company", params={"domain": "deepco.com"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["domain"] == "deepco.com"
+    assert data["name"] == "Deep Co"
+
+    with database.engine.begin() as conn:
+        row = conn.execute(
+            text("SELECT name FROM company_updated WHERE domain=:d"),
+            {"d": "deepco.com"},
+        ).mappings().first()
+    assert row is not None and row["name"] == "Deep Co"


### PR DESCRIPTION
## Summary
- add DeepSeek API client and helper
- provide `/api/company` endpoint that checks internal DB and calls DeepSeek when missing
- store DeepSeek results in `company_updated` and add regression tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8b62982688324845c43ba516f7018