### PR TITLE
Load DeepSeek API key from backend .env

### DIFF
--- a/backend/app/deepseek.py
+++ b/backend/app/deepseek.py
@@ -1,7 +1,13 @@
 import os
+from pathlib import Path
 from typing import Dict, Optional
 
 import httpx
+from dotenv import load_dotenv
+
+# Load environment variables from backend/.env so fetch_company_data can
+# access the DeepSeek API key during runtime and tests.
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
 
 DEEPSEEK_URL = "https://api.deepseek.com"
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ passlib[bcrypt]==1.7.4
 fastapi-jwt-auth==0.5.0
 pycountry==22.3.5
 httpx==0.27.0
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- ensure DeepSeek fallback loads API key from backend `.env`
- add python-dotenv dependency

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8c3804cc883248fa99b975476337f