### PR TITLE
Add job enrichment dashboard and API with attribution metrics

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ import uuid
 import re
 import json
 from io import StringIO, TextIOWrapper
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 from datetime import datetime
 
@@ -102,6 +102,31 @@ class ProcessedResult(BaseModel):
     notes: Optional[str]
     country: str
     industry: str
+    sources: Dict[str, str] = Field(default_factory=dict)
+
+
+class FieldStat(BaseModel):
+    enriched: int = 0
+    internal: int = 0
+    ai: int = 0
+
+
+class JobMeta(BaseModel):
+    job_id: str
+    name: str
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    total_records: int
+    processed_records: int
+    internal_fields: int
+    ai_fields: int
+    field_stats: Dict[str, FieldStat]
+
+
+class JobData(BaseModel):
+    meta: JobMeta
+    results: List[ProcessedResult]
 
 # Response schema for dashboard company listings
 class CompanyOut(BaseModel):
@@ -118,6 +143,7 @@ class CompanyOut(BaseModel):
 
 # In-memory task store (MVP)
 TASK_RESULTS: Dict[str, List[ProcessedResult]] = {}
+JOB_STORE: Dict[str, JobData] = {}
 
 # --- Normalization helpers ---
 
@@ -153,6 +179,103 @@ def extract_linkedin_slug(url: str) -> str:
         return match.group(1)
     # If no /company/ segment, assume provided slug
     return path.strip("/")
+
+
+def process_job_rows(
+    rows: List[Dict[str, Optional[str]]], db: Session, strategy: str
+) -> tuple[List[ProcessedResult], Dict[str, FieldStat], int, int]:
+    results: List[ProcessedResult] = []
+    fields = [
+        "companyName",
+        "domain",
+        "hq",
+        "size",
+        "linkedin_url",
+        "country",
+        "industry",
+    ]
+    field_stats = {name: FieldStat() for name in fields}
+    internal_total = 0
+    ai_total = 0
+
+    for idx, row in enumerate(rows, start=1):
+        name = row.get("company_name") or row.get("Company Name") or ""
+        domain = row.get("domain") or row.get("Domain") or ""
+        linkedin = row.get("linkedin_url") or row.get("LinkedIn URL") or ""
+        norm_domain = normalize_domain(domain)
+        sources: Dict[str, str] = {}
+        data: Dict[str, Any] = {
+            "companyName": name,
+            "domain": norm_domain,
+            "hq": "",
+            "size": "",
+            "linkedin_url": linkedin,
+            "country": "",
+            "industry": "",
+        }
+        company = None
+        if strategy in ("internal_only", "internal_then_ai_fallback") and norm_domain:
+            company = (
+                db.query(CompanyUpdated)
+                .filter(func.lower(CompanyUpdated.domain) == norm_domain)
+                .first()
+            )
+        if company:
+            data["companyName"] = company.name or name
+            data["domain"] = company.domain or norm_domain
+            data["hq"] = company.hq or ""
+            data["size"] = company.size or ""
+            data["linkedin_url"] = company.linkedin_url or ""
+            data["industry"] = company.industry or ""
+            data["country"] = (
+                company.countries[0] if getattr(company, "countries", None) else ""
+            )
+            for f in fields:
+                if data.get(f):
+                    sources[f] = "internal"
+                    field_stats[f].enriched += 1
+                    field_stats[f].internal += 1
+                    internal_total += 1
+        elif strategy in ("ai_only", "internal_then_ai_fallback"):
+            try:
+                fetched = fetch_company_data(
+                    name=name or None, domain=norm_domain or None, linkedin_url=linkedin or None
+                )
+                data["companyName"] = fetched.get("name") or name
+                data["domain"] = fetched.get("domain") or norm_domain
+                data["hq"] = fetched.get("hq") or ""
+                data["size"] = fetched.get("size") or ""
+                data["linkedin_url"] = fetched.get("linkedin_url") or ""
+                data["industry"] = fetched.get("industry") or ""
+                countries = fetched.get("countries") or []
+                data["country"] = countries[0] if countries else ""
+                for f in fields:
+                    if data.get(f):
+                        sources[f] = "ai"
+                        field_stats[f].enriched += 1
+                        field_stats[f].ai += 1
+                        ai_total += 1
+            except DeepSeekError:
+                pass
+
+        result = ProcessedResult(
+            id=idx,
+            companyName=data["companyName"],
+            originalData=row,
+            domain=data["domain"],
+            hq=data["hq"],
+            size=data["size"],
+            linkedin_url=data["linkedin_url"],
+            confidence="High" if sources else "Low",
+            matchType="Internal" if company else ("AI" if sources else "None"),
+            notes=None if sources else "Not found",
+            country=data["country"],
+            industry=data["industry"],
+            sources=sources,
+        )
+        results.append(result)
+
+    return results, field_stats, internal_total, ai_total
 
 # --- Enrichment ---
 def enrich_domains(
@@ -474,6 +597,99 @@ async def save_results(req: SaveResultsRequest):
 async def task_status(task_id: str):
     status = "completed" if task_id in TASK_RESULTS else "pending"
     return {"task_id": task_id, "status": status}
+
+
+@app.post("/api/jobs")
+async def create_job(
+    job_name: str = Form(...),
+    strategy: str = Form("internal_then_ai_fallback"),
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    authorize: AuthJWT = Depends(),
+):
+    authorize.jwt_required()
+    text = (await file.read()).decode("utf-8-sig", errors="ignore")
+    reader = csv.DictReader(StringIO(text))
+    headers = [h.lower() for h in (reader.fieldnames or [])]
+    if "company_name" not in headers or "domain" not in headers:
+        raise HTTPException(
+            status_code=400,
+            detail="CSV must include company_name and domain columns",
+        )
+    rows = [row for row in reader]
+    if len(rows) > 10000:
+        raise HTTPException(status_code=400, detail="CSV exceeds 10000 rows")
+    seen = set()
+    deduped = []
+    for row in rows:
+        d = (row.get("domain") or "").lower()
+        if d in seen:
+            continue
+        seen.add(d)
+        deduped.append(row)
+    results, stats, internal_total, ai_total = process_job_rows(
+        deduped, db, strategy
+    )
+    job_id = str(uuid.uuid4())
+    now = datetime.utcnow()
+    meta = JobMeta(
+        job_id=job_id,
+        name=job_name,
+        status="completed",
+        created_at=now,
+        updated_at=now,
+        total_records=len(deduped),
+        processed_records=len(deduped),
+        internal_fields=internal_total,
+        ai_fields=ai_total,
+        field_stats=stats,
+    )
+    JOB_STORE[job_id] = JobData(meta=meta, results=results)
+    current_user_email = authorize.get_jwt_subject()
+    user = db.query(User).filter(User.email == current_user_email).first()
+    if user:
+        user.enrichment_count += 1
+        db.commit()
+    return {"job_id": job_id}
+
+
+@app.get("/api/jobs")
+def list_jobs():
+    jobs = []
+    for job_id, data in JOB_STORE.items():
+        meta = data.meta
+        total = meta.internal_fields + meta.ai_fields
+        internal_pct = (meta.internal_fields / total * 100) if total else 0.0
+        ai_pct = (meta.ai_fields / total * 100) if total else 0.0
+        progress = (
+            meta.processed_records / meta.total_records * 100
+            if meta.total_records
+            else 0.0
+        )
+        jobs.append(
+            {
+                "job_id": job_id,
+                "name": meta.name,
+                "status": meta.status,
+                "progress": progress,
+                "created_at": meta.created_at,
+                "updated_at": meta.updated_at,
+                "internal_pct": internal_pct,
+                "ai_pct": ai_pct,
+            }
+        )
+    return {"jobs": jobs}
+
+
+@app.get("/api/jobs/{job_id}")
+def job_details(job_id: str):
+    data = JOB_STORE.get(job_id)
+    if not data:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return {
+        "meta": data.meta.dict(),
+        "results": [r.dict() for r in data.results],
+    }
 
 
 @app.get("/api/company", response_model=CompanyOut)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import { Button } from "./components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/ui/tabs";
 import { Badge } from "./components/ui/badge";
 import { UploadScreen } from "./components/UploadScreen";
+import { JobDashboard } from "./components/JobDashboard";
 import { ColumnMappingScreen } from "./components/ColumnMappingScreen";
 import { ResultsView } from "./components/ResultsView";
 import { Dashboard } from "./components/Dashboard";
@@ -27,7 +28,7 @@ const API = import.meta.env.VITE_API_BASE || "";
 export default function App() {
   const [user, setUser] = useState(null);
   const [authChecking, setAuthChecking] = useState(true);
-  const [activeTab, setActiveTab] = useState("dashboard");
+  const [activeTab, setActiveTab] = useState("jobs");
   const [uploadStep, setUploadStep] = useState("upload");
   const [showChat, setShowChat] = useState(false);
   const [showCompliance, setShowCompliance] = useState(true);
@@ -248,7 +249,11 @@ export default function App() {
               onValueChange={setActiveTab}
               className="w-full"
             >
-              <TabsList className="grid w-full grid-cols-1 sm:grid-cols-3 mb-8">
+              <TabsList className="grid w-full grid-cols-1 sm:grid-cols-4 mb-8">
+                <TabsTrigger value="jobs" className="flex items-center gap-2">
+                  <Database className="w-4 h-4" />
+                  Jobs
+                </TabsTrigger>
                 <TabsTrigger
                   value="dashboard"
                   className="flex items-center gap-2"
@@ -275,6 +280,9 @@ export default function App() {
                 </TabsTrigger>
               </TabsList>
 
+              <TabsContent value="jobs" className="space-y-6">
+                <JobDashboard />
+              </TabsContent>
               <TabsContent value="dashboard" className="space-y-6">
                 <Dashboard />
               </TabsContent>

--- a/frontend/src/components/JobDashboard.jsx
+++ b/frontend/src/components/JobDashboard.jsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from "react";
+import { JobUploader } from "./JobUploader";
+import { JobsTable } from "./JobsTable";
+import { JobDetails } from "./JobDetails";
+
+const API = import.meta.env.VITE_API_BASE || "";
+
+export function JobDashboard() {
+  const [jobs, setJobs] = useState([]);
+  const [selected, setSelected] = useState(null);
+
+  const fetchJobs = () => {
+    fetch(`${API}/api/jobs`)
+      .then((r) => r.json())
+      .then((d) => setJobs(d.jobs || []));
+  };
+
+  useEffect(() => {
+    fetchJobs();
+    const id = setInterval(fetchJobs, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <JobUploader onComplete={fetchJobs} />
+      <JobsTable jobs={jobs} onSelect={setSelected} />
+      {selected && <JobDetails jobId={selected} onClose={() => setSelected(null)} />}
+    </div>
+  );
+}

--- a/frontend/src/components/JobDetails.jsx
+++ b/frontend/src/components/JobDetails.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from "react";
+
+const API = import.meta.env.VITE_API_BASE || "";
+
+export function JobDetails({ jobId, onClose }) {
+  const [data, setData] = useState(null);
+  useEffect(() => {
+    fetch(`${API}/api/jobs/${jobId}`)
+      .then((r) => r.json())
+      .then(setData);
+  }, [jobId]);
+
+  if (!data) return null;
+  const { meta, results } = data;
+  const total = meta.internal_fields + meta.ai_fields;
+  const internalPct = total ? (meta.internal_fields / total) * 100 : 0;
+  const aiPct = total ? (meta.ai_fields / total) * 100 : 0;
+
+  return (
+    <div className="mt-4 p-4 border border-green-500 rounded bg-gray-900">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-lg">Job Details: {meta.name}</h2>
+        <button onClick={onClose} className="text-sm underline">
+          Close
+        </button>
+      </div>
+      <div className="grid sm:grid-cols-4 gap-4 mb-4 text-center">
+        <div className="bg-black p-2 rounded">Total {meta.total_records}</div>
+        <div className="bg-black p-2 rounded">Enriched {meta.processed_records}</div>
+        <div className="bg-black p-2 rounded">Internal {meta.internal_fields}</div>
+        <div className="bg-black p-2 rounded">AI {meta.ai_fields}</div>
+      </div>
+      <div className="mb-4">
+        <div className="w-full bg-gray-700 h-4 flex">
+          <div
+            className="bg-green-500"
+            style={{ width: `${internalPct}%` }}
+          />
+          <div className="bg-blue-500" style={{ width: `${aiPct}%` }} />
+        </div>
+        <div className="flex justify-between text-xs">
+          <span>{internalPct.toFixed(0)}% Internal</span>
+          <span>{aiPct.toFixed(0)}% AI</span>
+        </div>
+      </div>
+      <div className="overflow-auto max-h-64">
+        <table className="w-full text-xs">
+          <thead>
+            <tr>
+              <th className="p-1">Company</th>
+              <th className="p-1">Domain</th>
+              <th className="p-1">Industry</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((r) => (
+              <tr key={r.id} className="border-t border-gray-800">
+                <td className="p-1">{r.companyName}</td>
+                <td className="p-1">
+                  {r.domain}
+                  {r.sources.domain && (
+                    <span className="ml-1 px-1 text-[10px] rounded bg-gray-700">
+                      {r.sources.domain === "internal" ? "INT" : "AI"}
+                    </span>
+                  )}
+                </td>
+                <td className="p-1">
+                  {r.industry}
+                  {r.sources.industry && (
+                    <span className="ml-1 px-1 text-[10px] rounded bg-gray-700">
+                      {r.sources.industry === "internal" ? "INT" : "AI"}
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/JobUploader.jsx
+++ b/frontend/src/components/JobUploader.jsx
@@ -1,0 +1,94 @@
+import React, { useRef, useState } from "react";
+
+const API = import.meta.env.VITE_API_BASE || "";
+
+export function JobUploader({ onComplete }) {
+  const [file, setFile] = useState(null);
+  const [jobName, setJobName] = useState("");
+  const [strategy, setStrategy] = useState("internal_then_ai_fallback");
+  const inputRef = useRef(null);
+
+  const handleBrowse = () => inputRef.current?.click();
+
+  const handleFile = (f) => {
+    if (!f) return;
+    setFile(f);
+    if (!jobName) {
+      const base = f.name.replace(/\.csv$/i, "");
+      setJobName(base);
+    }
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    if (e.dataTransfer.files?.length) {
+      handleFile(e.dataTransfer.files[0]);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!file) return;
+    const form = new FormData();
+    form.append("file", file);
+    form.append("job_name", jobName);
+    form.append("strategy", strategy);
+    const res = await fetch(`${API}/api/jobs`, { method: "POST", body: form });
+    if (res.ok) {
+      setFile(null);
+      setJobName("");
+      setStrategy("internal_then_ai_fallback");
+      onComplete && onComplete();
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div
+        className="border-2 border-dashed border-green-500 rounded p-6 text-center cursor-pointer"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDrop}
+        onClick={handleBrowse}
+      >
+        {file ? <p>{file.name}</p> : <p>Drag & drop CSV here or click to browse</p>}
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".csv"
+          onChange={(e) => handleFile(e.target.files?.[0])}
+          className="hidden"
+        />
+      </div>
+      <div className="grid sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm mb-1">Job Name</label>
+          <input
+            value={jobName}
+            onChange={(e) => setJobName(e.target.value)}
+            className="w-full p-2 bg-black border border-green-500 rounded"
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Strategy</label>
+          <select
+            value={strategy}
+            onChange={(e) => setStrategy(e.target.value)}
+            className="w-full p-2 bg-black border border-green-500 rounded"
+          >
+            <option value="internal_only">internal_only</option>
+            <option value="ai_only">ai_only</option>
+            <option value="internal_then_ai_fallback">internal_then_ai_fallback</option>
+          </select>
+        </div>
+      </div>
+      <div className="text-right">
+        <button
+          onClick={handleSubmit}
+          disabled={!file}
+          className="px-4 py-2 bg-green-600 text-black rounded disabled:opacity-50"
+        >
+          Start Job
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/JobsTable.jsx
+++ b/frontend/src/components/JobsTable.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+
+export function JobsTable({ jobs, onSelect }) {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left">
+          <th className="p-2">Job Name</th>
+          <th className="p-2">Status</th>
+          <th className="p-2">Progress</th>
+          <th className="p-2">Created</th>
+          <th className="p-2">Attribution</th>
+          <th className="p-2">Downloads</th>
+        </tr>
+      </thead>
+      <tbody>
+        {jobs.map((j) => (
+          <tr
+            key={j.job_id}
+            className="border-t border-gray-800 hover:bg-gray-800 cursor-pointer"
+            onClick={() => onSelect && onSelect(j.job_id)}
+          >
+            <td className="p-2">{j.name}</td>
+            <td className="p-2">{j.status}</td>
+            <td className="p-2">{j.progress.toFixed(0)}%</td>
+            <td className="p-2">
+              {new Date(j.created_at).toLocaleString()}
+            </td>
+            <td className="p-2">
+              <div className="w-32 bg-gray-700 h-2 mb-1 flex">
+                <div
+                  className="bg-green-500 h-2"
+                  style={{ width: `${j.internal_pct}%` }}
+                />
+                <div
+                  className="bg-blue-500 h-2"
+                  style={{ width: `${j.ai_pct}%` }}
+                />
+              </div>
+              <div className="text-xs flex justify-between">
+                <span>{j.internal_pct.toFixed(0)}% INT</span>
+                <span>{j.ai_pct.toFixed(0)}% AI</span>
+              </div>
+            </td>
+            <td className="p-2 space-x-2">
+              <button
+                disabled={j.status !== "completed"}
+                className="px-2 py-1 border border-green-500 rounded disabled:opacity-50"
+              >
+                Full CSV
+              </button>
+              <button
+                disabled={j.status !== "completed"}
+                className="px-2 py-1 border border-green-500 rounded disabled:opacity-50"
+              >
+                Failed
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,63 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from test_auth import setup_app
+from test_admin_upload import _create_company_table
+
+
+def test_job_creation_and_metrics(tmp_path, monkeypatch):
+    app, database, _ = setup_app(tmp_path)
+    import backend.app.main as main
+    _create_company_table(database.engine)
+    with database.engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO company_updated (name, domain) VALUES ('Existing', 'exist.com')")
+        )
+
+    def fake_fetch(*, name=None, domain=None, linkedin_url=None):
+        return {
+            "name": name or "AI Co",
+            "domain": domain or "",
+            "hq": "HQ",
+            "size": "10",
+            "industry": "Tech",
+            "linkedin_url": "https://linkedin.com/company/aico",
+            "countries": ["US"],
+        }
+
+    monkeypatch.setattr(main, "fetch_company_data", fake_fetch)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/auth/signup",
+        json={"email": "job_user@example.com", "password": "secret", "fullName": "User"},
+    )
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    csv_content = "company_name,domain\nExisting,exist.com\nAI Company,aico.com\n"
+    files = {"file": ("test.csv", csv_content, "text/csv")}
+    data = {"job_name": "job1", "strategy": "internal_then_ai_fallback"}
+    resp = client.post("/api/jobs", headers=headers, data=data, files=files)
+    assert resp.status_code == 200
+    job_id = resp.json()["job_id"]
+
+    resp = client.get("/api/jobs")
+    assert resp.status_code == 200
+    jobs = resp.json()["jobs"]
+    job = next(j for j in jobs if j["job_id"] == job_id)
+    assert job["progress"] == 100
+    assert job["internal_pct"] > 0
+    assert job["ai_pct"] > 0
+
+    resp = client.get(f"/api/jobs/{job_id}")
+    assert resp.status_code == 200
+    meta = resp.json()["meta"]
+    assert meta["total_records"] == 2
+    assert meta["processed_records"] == 2
+    assert meta["internal_fields"] > 0
+    assert meta["ai_fields"] > 0
+    results = resp.json()["results"]
+    assert len(results) == 2
+    ai_row = next(r for r in results if r["domain"] == "aico.com")
+    assert ai_row["sources"]["domain"] == "ai"


### PR DESCRIPTION
## Summary
- add job processing models with per-field attribution and source tracking
- expose /api/jobs endpoints for CSV upload, job listing, and job details
- build React job dashboard with uploader, monitoring table, and detail view
- cover job API with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8df8f58bc83249ae18a9106d40bbb