### PR TITLE
feat: add column mapping to job workflow

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -604,32 +604,61 @@ async def create_job(
     job_name: str = Form(...),
     strategy: str = Form("internal_then_ai_fallback"),
     file: UploadFile = File(...),
+    column_map: Optional[str] = Form(None),
     db: Session = Depends(get_db),
     authorize: AuthJWT = Depends(),
 ):
     authorize.jwt_required()
     text = (await file.read()).decode("utf-8-sig", errors="ignore")
     reader = csv.DictReader(StringIO(text))
-    headers = [h.lower() for h in (reader.fieldnames or [])]
-    if "company_name" not in headers or "domain" not in headers:
+
+    # Normalize headers to simplify mapping lookups
+    raw_headers = reader.fieldnames or []
+    normalized_headers = [h.strip().lower() for h in raw_headers if h is not None]
+    reader.fieldnames = normalized_headers
+
+    mapping: Dict[str, str] = {}
+    if column_map:
+        try:
+            mapping = json.loads(column_map)
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid column_map")
+        mapping = {
+            k.lower(): v.strip().lower() for k, v in mapping.items() if isinstance(v, str)
+        }
+
+    required = {"domain", "company_name"}
+    headers_set = set(normalized_headers)
+    missing = {
+        field for field in required if mapping.get(field, field) not in headers_set
+    }
+    if missing:
         raise HTTPException(
             status_code=400,
-            detail="CSV must include company_name and domain columns",
+            detail=f"CSV must include columns: {', '.join(sorted(missing))}",
         )
-    rows = [row for row in reader]
+
+    rows: List[Dict[str, Any]] = []
+    for row in reader:
+        normalized = dict(row)
+        for field in ("domain", "company_name", "linkedin_url"):
+            normalized[field] = row.get(mapping.get(field, field))
+        rows.append(normalized)
+
     if len(rows) > 10000:
         raise HTTPException(status_code=400, detail="CSV exceeds 10000 rows")
+
     seen = set()
-    deduped = []
+    deduped: List[Dict[str, Any]] = []
     for row in rows:
         d = (row.get("domain") or "").lower()
-        if d in seen:
+        if d and d in seen:
             continue
-        seen.add(d)
+        if d:
+            seen.add(d)
         deduped.append(row)
-    results, stats, internal_total, ai_total = process_job_rows(
-        deduped, db, strategy
-    )
+
+    results, stats, internal_total, ai_total = process_job_rows(deduped, db, strategy)
     job_id = str(uuid.uuid4())
     now = datetime.utcnow()
     meta = JobMeta(

--- a/frontend/src/components/ColumnMappingScreen.jsx
+++ b/frontend/src/components/ColumnMappingScreen.jsx
@@ -44,7 +44,7 @@ export function ColumnMappingScreen({ uploadedFile, onMappingComplete, onBack })
       return result;
     });
 
-    onMappingComplete(mapped);
+    onMappingComplete(mapped, mapping);
     setShowModal(false);
   };
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -3,6 +3,7 @@ from sqlalchemy import text
 
 from test_auth import setup_app
 from test_admin_upload import _create_company_table
+import json
 
 
 def test_job_creation_and_metrics(tmp_path, monkeypatch):
@@ -61,3 +62,47 @@ def test_job_creation_and_metrics(tmp_path, monkeypatch):
     assert len(results) == 2
     ai_row = next(r for r in results if r["domain"] == "aico.com")
     assert ai_row["sources"]["domain"] == "ai"
+
+
+def test_job_creation_with_column_mapping(tmp_path, monkeypatch):
+    app, database, _ = setup_app(tmp_path)
+    import backend.app.main as main
+    _create_company_table(database.engine)
+
+    def fake_fetch(*, name=None, domain=None, linkedin_url=None):
+        return {
+            "name": name or "AI Co",
+            "domain": domain or "",
+            "hq": "HQ",
+            "size": "10",
+            "industry": "Tech",
+            "linkedin_url": "https://linkedin.com/company/aico",
+            "countries": ["US"],
+        }
+
+    monkeypatch.setattr(main, "fetch_company_data", fake_fetch)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/auth/signup",
+        json={"email": "map_user@example.com", "password": "secret", "fullName": "User"},
+    )
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    csv_content = "CompanyName,WebDomain\nAI Company,aico.com\n"
+    files = {"file": ("test.csv", csv_content, "text/csv")}
+    column_map = json.dumps({"company_name": "companyname", "domain": "webdomain"})
+    data = {
+        "job_name": "jobmap",
+        "strategy": "internal_then_ai_fallback",
+        "column_map": column_map,
+    }
+    resp = client.post("/api/jobs", headers=headers, data=data, files=files)
+    assert resp.status_code == 200
+    job_id = resp.json()["job_id"]
+
+    resp = client.get(f"/api/jobs/{job_id}")
+    assert resp.status_code == 200
+    meta = resp.json()["meta"]
+    assert meta["total_records"] == 1


### PR DESCRIPTION
## Summary
- allow jobs endpoint to accept column mapping and deduplicate using mapped headers
- add column mapping step to Jobs UI before starting a job
- expose mapping from column mapping screen
- test job creation with custom column mapping

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a95b9006f0832497ff538cc19b8385