### PR TITLE
feat: track user activity for dashboard

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -43,6 +43,23 @@ def init_db():
                 )
             if "last_login" not in user_columns:
                 conn.execute(text("ALTER TABLE users ADD COLUMN last_login TIMESTAMP"))
+            if "last_enrichment_at" not in user_columns:
+                conn.execute(
+                    text("ALTER TABLE users ADD COLUMN last_enrichment_at TIMESTAMP")
+                )
+            if "activity_log" not in user_columns:
+                if engine.dialect.name == "postgresql":
+                    conn.execute(
+                        text(
+                            "ALTER TABLE users ADD COLUMN activity_log JSON DEFAULT '[]'::json"
+                        )
+                    )
+                else:
+                    conn.execute(
+                        text(
+                            "ALTER TABLE users ADD COLUMN activity_log JSON DEFAULT '[]'"
+                        )
+                    )
             if "account_status" not in user_columns:
                 conn.execute(
                     text(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, JSON
 from sqlalchemy.dialects.postgresql import ARRAY
 from .database import Base
 
@@ -14,6 +14,8 @@ class User(Base):
     role = Column(String, nullable=False)
     enrichment_count = Column(Integer, default=0, nullable=False)
     last_login = Column(DateTime, nullable=True)
+    last_enrichment_at = Column(DateTime, nullable=True)
+    activity_log = Column(JSON, default=list)
     account_status = Column(String, default="Active", nullable=False)
 
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import { JobDashboard } from "./components/JobDashboard";
 import { ColumnMappingScreen } from "./components/ColumnMappingScreen";
 import { ResultsView } from "./components/ResultsView";
 import { Dashboard } from "./components/Dashboard";
+import { UserDashboard } from "./components/UserDashboard";
 import { ChatPanel } from "./components/ChatPanel";
 import { ComplianceBanner } from "./components/ComplianceBanner";
 import { LandingPage } from "./components/LandingPage";
@@ -281,6 +282,7 @@ export default function App() {
               </TabsList>
 
               <TabsContent value="dashboard" className="space-y-6">
+                <UserDashboard token={user.token} />
                 <JobDashboard />
               </TabsContent>
               <TabsContent value="company-data" className="space-y-6">

--- a/frontend/src/components/UserDashboard.jsx
+++ b/frontend/src/components/UserDashboard.jsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react";
+
+const API = import.meta.env.VITE_API_BASE || "";
+
+export function UserDashboard({ token }) {
+  const [stats, setStats] = useState(null);
+
+  useEffect(() => {
+    if (!token) return;
+    fetch(`${API}/api/dashboard`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => r.json())
+      .then((d) => setStats(d.stats || {}));
+  }, [token]);
+
+  if (!stats) {
+    return (
+      <div className="bg-black p-4 rounded border border-green-500 text-green-400">
+        Loading...
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-black p-4 rounded border border-green-500 text-green-400 space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
+        <div>
+          <div className="text-lg font-bold">{stats.enrichment_count || 0}</div>
+          <div className="text-xs text-green-300">Enrichment Jobs</div>
+        </div>
+        <div>
+          <div className="text-lg font-bold">
+            {stats.last_login ? new Date(stats.last_login).toLocaleString() : "—"}
+          </div>
+          <div className="text-xs text-green-300">Last Login</div>
+        </div>
+        <div>
+          <div className="text-lg font-bold">
+            {stats.last_enrichment_at
+              ? new Date(stats.last_enrichment_at).toLocaleString()
+              : "—"}
+          </div>
+          <div className="text-xs text-green-300">Last Enrichment</div>
+        </div>
+      </div>
+      {stats.activity_log && stats.activity_log.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold mb-2">Recent Activity</h3>
+          <ul className="text-xs space-y-1">
+            {stats.activity_log
+              .slice()
+              .reverse()
+              .slice(0, 5)
+              .map((a, i) => (
+                <li key={i}>
+                  {new Date(a.timestamp).toLocaleString()} – {a.action}
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -62,6 +62,7 @@ def test_signup_and_tracking(tmp_path):
     assert user.enrichment_count == 0
     assert user.account_status == "Active"
     assert user.last_login is None
+    assert user.activity_log and user.activity_log[0]["action"] == "signup"
 
     # Sign in to update last_login
     resp = client.post(
@@ -71,6 +72,7 @@ def test_signup_and_tracking(tmp_path):
     assert resp.status_code == 200
     db.refresh(user)
     assert user.last_login is not None
+    assert any(a["action"] == "signin" for a in user.activity_log)
 
     # Process a request to increment enrichment_count
     headers = {"Authorization": f"Bearer {token}"}
@@ -78,6 +80,8 @@ def test_signup_and_tracking(tmp_path):
     assert resp.status_code == 200
     db.refresh(user)
     assert user.enrichment_count == 1
+    assert user.last_enrichment_at is not None
+    assert any(a["action"] == "enrichment" for a in user.activity_log)
     db.close()
 
 


### PR DESCRIPTION
## Summary
- track signup, signin, and enrichment actions in a user activity log
- expose user stats through authenticated /api/dashboard endpoint
- add React UserDashboard to display enrichment counts and recent activity

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aae62ed9888324989a62600aac8480