### PR TITLE
Align frontend pages with login theme

### DIFF
--- a/frontend/src/components/CompanyDetailsPanel.jsx
+++ b/frontend/src/components/CompanyDetailsPanel.jsx
@@ -52,11 +52,11 @@ export function CompanyDetailsPanel({ company, onClose }) {
         role="dialog"
         aria-modal="true"
         aria-label="Company details"
-        className={`fixed top-0 right-0 h-full w-96 max-w-full bg-gray-900 text-green-400 shadow-lg transform transition-transform duration-300 border-l border-green-500 ${
+        className={`fixed top-0 right-0 h-full w-96 max-w-full bg-white shadow-lg transform transition-transform duration-300 border-l ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
-        <div className="p-4 border-b border-green-500 flex items-center justify-between">
+        <div className="p-4 border-b flex items-center justify-between">
           <div className="flex items-center gap-3">
             {company?.domain ? (
               <img
@@ -69,7 +69,7 @@ export function CompanyDetailsPanel({ company, onClose }) {
           </div>
           <button
             onClick={onClose}
-            className="text-green-400 hover:text-green-200"
+            className="text-gray-600 hover:text-gray-800"
             aria-label="Close panel"
           >
             ✕
@@ -79,19 +79,19 @@ export function CompanyDetailsPanel({ company, onClose }) {
         {isOpen && (
           <div className="p-4 space-y-3 text-sm">
             <p>
-              <strong className="text-green-300">Name:</strong>{' '}
+              <strong className="text-primary">Name:</strong>{' '}
               {company?.name || company?.['Original Name'] || 'N/A'}
             </p>
 
             <p className="break-all">
-              <strong className="text-green-300">Domain:</strong>{' '}
+              <strong className="text-primary">Domain:</strong>{' '}
               {company?.domain ? (
                 siteHref ? (
                   <a
                     href={siteHref}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-blue-400 hover:underline"
+                    className="text-primary hover:underline"
                     title="Open website"
                   >
                     {company.domain}
@@ -105,63 +105,63 @@ export function CompanyDetailsPanel({ company, onClose }) {
             </p>
 
             <p>
-              <strong className="text-green-300">Headquarters:</strong>{' '}
+              <strong className="text-primary">Headquarters:</strong>{' '}
               {company?.hq || 'N/A'}
             </p>
 
             <p>
-              <strong className="text-green-300">Country / Region:</strong>{' '}
+              <strong className="text-primary">Country / Region:</strong>{' '}
               {company?.countries || company?.country || 'N/A'}
             </p>
 
             <p>
-              <strong className="text-green-300">Industry:</strong>{' '}
+              <strong className="text-primary">Industry:</strong>{' '}
               {company?.industry || 'N/A'}
             </p>
 
             {company?.subindustry ? (
               <p>
-                <strong className="text-green-300">Subindustry:</strong>{' '}
+                <strong className="text-primary">Subindustry:</strong>{' '}
                 {company.subindustry}
               </p>
             ) : null}
 
             {company?.size ? (
               <p>
-                <strong className="text-green-300">Company Size:</strong>{' '}
+                <strong className="text-primary">Company Size:</strong>{' '}
                 {company.size}
               </p>
             ) : null}
 
             {company?.['Legal Name'] ? (
               <p className="break-all">
-                <strong className="text-green-300">Legal Name:</strong>{' '}
+                <strong className="text-primary">Legal Name:</strong>{' '}
                 {company['Legal Name']}
               </p>
             ) : null}
 
             {company?.slug ? (
               <p className="break-all">
-                <strong className="text-green-300">Slug:</strong> {company.slug}
+                <strong className="text-primary">Slug:</strong> {company.slug}
               </p>
             ) : null}
 
             {company?.keywords_cntxt ? (
               <p className="break-words">
-                <strong className="text-green-300">Keywords:</strong>{' '}
+                <strong className="text-primary">Keywords:</strong>{' '}
                 {company.keywords_cntxt}
               </p>
             ) : null}
 
             <p className="break-all">
-              <strong className="text-green-300">LinkedIn:</strong>{' '}
+              <strong className="text-primary">LinkedIn:</strong>{' '}
               {company?.linkedin_url ? (
                 linkedInHref ? (
                   <a
                     href={linkedInHref}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-blue-400 hover:underline"
+                    className="text-primary hover:underline"
                     title="Open LinkedIn"
                   >
                     {company.linkedin_url}

--- a/frontend/src/components/CompanyTable.jsx
+++ b/frontend/src/components/CompanyTable.jsx
@@ -73,74 +73,74 @@ export function CompanyTable({ filters = {} }) {
   const endItem = Math.min(page * pageSize, total);
 
   return (
-    <div className="relative text-green-400 font-mono">
+    <div className="relative">
       <div className="overflow-x-auto">
-        <table className="min-w-full border border-green-500">
-          <thead className="bg-gray-900">
+        <table className="min-w-full border border-gray-200">
+          <thead className="bg-gray-50">
             <tr>
               <th
-                className="px-4 py-2 border border-green-500 cursor-pointer"
+                className="px-4 py-2 border border-gray-200 cursor-pointer"
                 onClick={() => handleSort("name")}
               >
                 Company Name
               </th>
               <th
-                className="px-4 py-2 border border-green-500 cursor-pointer"
+                className="px-4 py-2 border border-gray-200 cursor-pointer"
                 onClick={() => handleSort("domain")}
               >
                 Domain
               </th>
               <th
-                className="px-4 py-2 border border-green-500 cursor-pointer"
+                className="px-4 py-2 border border-gray-200 cursor-pointer"
                 onClick={() => handleSort("hq")}
               >
                 Headquarters
               </th>
               <th
-                className="px-4 py-2 border border-green-500 cursor-pointer"
+                className="px-4 py-2 border border-gray-200 cursor-pointer"
                 onClick={() => handleSort("size")}
               >
                 Employees
               </th>
               <th
-                className="px-4 py-2 border border-green-500 cursor-pointer"
+                className="px-4 py-2 border border-gray-200 cursor-pointer"
                 onClick={() => handleSort("industry")}
               >
                 Industry
               </th>
-              <th className="px-4 py-2 border border-green-500">LinkedIn</th>
+              <th className="px-4 py-2 border border-gray-200">LinkedIn</th>
             </tr>
           </thead>
           <tbody>
             {companies.map((c) => (
               <tr
                 key={c.id}
-                className="hover:bg-gray-800 transition-colors cursor-pointer"
+                className="hover:bg-gray-100 transition-colors cursor-pointer"
                 onClick={() => setSelected(c)}
               >
-                <td className="px-4 py-2 border border-green-500">
+                <td className="px-4 py-2 border border-gray-200">
                   {c.name || "N/A"}
                 </td>
-                <td className="px-4 py-2 border border-green-500">
+                <td className="px-4 py-2 border border-gray-200">
                   {c.domain}
                 </td>
-                <td className="px-4 py-2 border border-green-500">
+                <td className="px-4 py-2 border border-gray-200">
                   {c.hq || "N/A"}
                 </td>
-                <td className="px-4 py-2 border border-green-500">
+                <td className="px-4 py-2 border border-gray-200">
                   {c.size || "N/A"}
                 </td>
-                <td className="px-4 py-2 border border-green-500">
+                <td className="px-4 py-2 border border-gray-200">
                   {c.industry || "N/A"}
                 </td>
-                <td className="px-4 py-2 border border-green-500 text-center">
+                <td className="px-4 py-2 border border-gray-200 text-center">
                   {c.linkedin_url ? (
                     <a
                       href={formatLinkedInUrl(c.linkedin_url)}
                       target="_blank"
                       rel="noopener noreferrer"
                       onClick={(e) => e.stopPropagation()}
-                      className="text-blue-400 hover:underline"
+                      className="text-primary hover:underline"
                     >
                       Link
                     </a>
@@ -167,7 +167,7 @@ export function CompanyTable({ filters = {} }) {
               setPageSize(Number(e.target.value));
               setPage(1);
             }}
-            className="bg-gray-900 border border-green-500 rounded px-2 py-1"
+            className="border rounded px-2 py-1"
           >
             {[10, 20, 50, 100].map((size) => (
               <option key={size} value={size}>
@@ -180,7 +180,7 @@ export function CompanyTable({ filters = {} }) {
           <button
             onClick={() => setPage((p) => p - 1)}
             disabled={page === 1}
-            className="px-2 py-1 border border-green-500 rounded disabled:opacity-50"
+            className="px-2 py-1 border rounded disabled:opacity-50"
           >
             Previous
           </button>
@@ -193,8 +193,8 @@ export function CompanyTable({ filters = {} }) {
               <button
                 key={p}
                 onClick={() => setPage(p)}
-                className={`px-2 py-1 border border-green-500 rounded ${
-                  p === page ? "bg-green-500 text-black" : ""
+                className={`px-2 py-1 border rounded ${
+                  p === page ? "bg-purple-600 text-white" : ""
                 }`}
               >
                 {p}
@@ -204,7 +204,7 @@ export function CompanyTable({ filters = {} }) {
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={page === totalPages}
-            className="px-2 py-1 border border-green-500 rounded disabled:opacity-50"
+            className="px-2 py-1 border rounded disabled:opacity-50"
           >
             Next
           </button>

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -6,8 +6,8 @@ export function Dashboard() {
   const [filters, setFilters] = useState({});
 
   return (
-    <div className="bg-black p-4 rounded border border-green-500">
-      <div className="flex flex-col md:flex-row">
+    <div className="card p-4">
+      <div className="flex flex-col md:flex-row gap-4">
         <FilterPanel onApply={setFilters} onClear={() => setFilters({})} />
         <div className="flex-1">
           <CompanyTable filters={filters} />

--- a/frontend/src/components/FilterPanel.jsx
+++ b/frontend/src/components/FilterPanel.jsx
@@ -142,18 +142,18 @@ export function FilterPanel({ onApply, onClear }) {
   };
 
   return (
-    <div className="bg-gray-900 border border-green-500 p-4 rounded w-full md:w-64 mb-4 md:mb-0 md:mr-4 text-green-400">
-      <h2 className="text-lg font-semibold mb-4 text-green-400">Filters</h2>
+    <div className="card p-4 w-full md:w-64 mb-4 md:mb-0 md:mr-4">
+      <h2 className="text-lg font-semibold mb-4 text-primary">Filters</h2>
 
       {/* Company Name */}
       <div className="mb-4">
-        <label className="block text-sm font-medium mb-1 text-green-400">Company Name</label>
+        <label className="block text-sm font-medium mb-1">Company Name</label>
         <input
           type="text"
           list="company-suggestions"
           value={companyName}
           onChange={(e) => setCompanyName(e.target.value)}
-          className="w-full p-2 border border-green-500 rounded bg-black text-green-400 placeholder-gray-500"
+          className="w-full p-2 border rounded"
           placeholder="Type a company name"
         />
         <datalist id="company-suggestions">
@@ -165,13 +165,13 @@ export function FilterPanel({ onApply, onClear }) {
 
       {/* Domain */}
       <div className="mb-4">
-        <label className="block text-sm font-medium mb-1 text-green-400">Company Domain</label>
+        <label className="block text-sm font-medium mb-1">Company Domain</label>
         <input
           type="text"
           list="domain-suggestions"
           value={domain}
           onChange={(e) => setDomain(e.target.value)}
-          className="w-full p-2 border border-green-500 rounded bg-black text-green-400 placeholder-gray-500"
+          className="w-full p-2 border rounded"
           placeholder="https://example.com"
         />
         <datalist id="domain-suggestions">
@@ -183,14 +183,14 @@ export function FilterPanel({ onApply, onClear }) {
 
       {/* Employee Size */}
       <div className="mb-4">
-        <p className="text-sm font-medium mb-1 text-green-400">Number of Employees</p>
+        <p className="text-sm font-medium mb-1">Number of Employees</p>
         {ranges.map((r) => (
           <label key={r.label} className="flex items-center space-x-2 mb-1">
             <input
               type="checkbox"
               checked={selectedRanges.includes(r.label)}
               onChange={() => handleRangeChange(r.label)}
-              className="accent-green-500"
+              className="accent-purple-600"
             />
             <span>{r.label}</span>
           </label>
@@ -201,7 +201,7 @@ export function FilterPanel({ onApply, onClear }) {
             value={customMin}
             onChange={handleCustomMinChange}
             placeholder="Min"
-            className="w-20 p-1 border border-green-500 rounded bg-black text-green-400 placeholder-gray-500"
+            className="w-20 p-1 border rounded"
           />
           <span>-</span>
           <input
@@ -209,21 +209,21 @@ export function FilterPanel({ onApply, onClear }) {
             value={customMax}
             onChange={handleCustomMaxChange}
             placeholder="Max"
-            className="w-20 p-1 border border-green-500 rounded bg-black text-green-400 placeholder-gray-500"
+            className="w-20 p-1 border rounded"
           />
         </div>
       </div>
 
       {/* Headquarters */}
       <div className="mb-4">
-        <label className="block text-sm font-medium mb-1 text-green-400">
+        <label className="block text-sm font-medium mb-1">
           Headquarters Location
         </label>
         <input
           type="text"
           value={hq}
           onChange={(e) => setHq(e.target.value)}
-          className="w-full p-2 border border-green-500 rounded bg-black text-green-400 placeholder-gray-500"
+          className="w-full p-2 border rounded"
           placeholder="City or Country"
         />
       </div>
@@ -232,13 +232,13 @@ export function FilterPanel({ onApply, onClear }) {
       <div className="flex space-x-2">
         <button
           onClick={applyFilters}
-          className="flex-1 px-4 py-2 bg-gray-900 border border-green-500 rounded text-green-400 hover:bg-gray-800"
+          className="flex-1 btn btn-primary"
         >
           Apply Filters
         </button>
         <button
           onClick={clearFilters}
-          className="flex-1 px-4 py-2 bg-black border border-green-500 rounded text-green-400 hover:bg-gray-900"
+          className="flex-1 btn btn-secondary"
         >
           Clear Filters
         </button>

--- a/frontend/src/components/JobDetails.jsx
+++ b/frontend/src/components/JobDetails.jsx
@@ -17,7 +17,7 @@ export function JobDetails({ jobId, onClose }) {
   const aiPct = total ? (meta.ai_fields / total) * 100 : 0;
 
   return (
-    <div className="mt-4 p-4 border border-green-500 rounded bg-gray-900">
+    <div className="mt-4 card p-4">
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-lg">Job Details</h2>
         <button onClick={onClose} className="text-sm underline">
@@ -25,15 +25,15 @@ export function JobDetails({ jobId, onClose }) {
         </button>
       </div>
       <div className="grid sm:grid-cols-4 gap-4 mb-4 text-center">
-        <div className="bg-black p-2 rounded">Total {meta.total_records}</div>
-        <div className="bg-black p-2 rounded">Enriched {meta.processed_records}</div>
-        <div className="bg-black p-2 rounded">Internal {meta.internal_fields}</div>
-        <div className="bg-black p-2 rounded">AI {meta.ai_fields}</div>
+        <div className="bg-gray-100 p-2 rounded">Total {meta.total_records}</div>
+        <div className="bg-gray-100 p-2 rounded">Enriched {meta.processed_records}</div>
+        <div className="bg-gray-100 p-2 rounded">Internal {meta.internal_fields}</div>
+        <div className="bg-gray-100 p-2 rounded">AI {meta.ai_fields}</div>
       </div>
       <div className="mb-4">
-        <div className="w-full bg-gray-700 h-4 flex">
+        <div className="w-full bg-gray-200 h-4 flex">
           <div
-            className="bg-green-500"
+            className="bg-purple-600"
             style={{ width: `${internalPct}%` }}
           />
           <div className="bg-blue-500" style={{ width: `${aiPct}%` }} />
@@ -54,12 +54,12 @@ export function JobDetails({ jobId, onClose }) {
           </thead>
           <tbody>
             {results.map((r) => (
-              <tr key={r.id} className="border-t border-gray-800">
+              <tr key={r.id} className="border-t border-gray-200">
                 <td className="p-1">{r.companyName}</td>
                 <td className="p-1">
                   {r.domain}
                   {r.sources.domain && (
-                    <span className="ml-1 px-1 text-[10px] rounded bg-gray-700">
+                    <span className="ml-1 px-1 text-[10px] rounded bg-gray-200">
                       {r.sources.domain === "internal" ? "INT" : "AI"}
                     </span>
                   )}
@@ -67,7 +67,7 @@ export function JobDetails({ jobId, onClose }) {
                 <td className="p-1">
                   {r.industry}
                   {r.sources.industry && (
-                    <span className="ml-1 px-1 text-[10px] rounded bg-gray-700">
+                    <span className="ml-1 px-1 text-[10px] rounded bg-gray-200">
                       {r.sources.industry === "internal" ? "INT" : "AI"}
                     </span>
                   )}

--- a/frontend/src/components/JobsTable.jsx
+++ b/frontend/src/components/JobsTable.jsx
@@ -16,7 +16,7 @@ export function JobsTable({ jobs, onSelect }) {
         {jobs.map((j) => (
           <tr
             key={j.job_id}
-            className="border-t border-gray-800 hover:bg-gray-800 cursor-pointer"
+            className="border-t hover:bg-gray-100 cursor-pointer"
             onClick={() => onSelect && onSelect(j.job_id)}
           >
             <td className="p-2">{j.status}</td>
@@ -25,9 +25,9 @@ export function JobsTable({ jobs, onSelect }) {
               {new Date(j.created_at).toLocaleString()}
             </td>
             <td className="p-2">
-              <div className="w-32 bg-gray-700 h-2 mb-1 flex">
+              <div className="w-32 bg-gray-200 h-2 mb-1 flex">
                 <div
-                  className="bg-green-500 h-2"
+                  className="bg-purple-600 h-2"
                   style={{ width: `${j.internal_pct}%` }}
                 />
                 <div
@@ -43,13 +43,13 @@ export function JobsTable({ jobs, onSelect }) {
             <td className="p-2 space-x-2">
               <button
                 disabled={j.status !== "completed"}
-                className="px-2 py-1 border border-green-500 rounded disabled:opacity-50"
+                className="px-2 py-1 border rounded disabled:opacity-50"
               >
                 Full CSV
               </button>
               <button
                 disabled={j.status !== "completed"}
-                className="px-2 py-1 border border-green-500 rounded disabled:opacity-50"
+                className="px-2 py-1 border rounded disabled:opacity-50"
               >
                 Failed
               </button>

--- a/frontend/src/components/ResultsView.jsx
+++ b/frontend/src/components/ResultsView.jsx
@@ -48,51 +48,45 @@ export function ResultsView({ results }) {
   };
 
   return (
-    <div className="text-green-400 font-mono">
+    <div>
       <div className="flex gap-4 mb-4">
-        <button
-          onClick={downloadCSV}
-          className="px-4 py-2 bg-gray-900 border border-green-500 rounded hover:bg-gray-800"
-        >
+        <button onClick={downloadCSV} className="btn btn-primary">
           Download Enriched CSV
         </button>
-        <button
-          onClick={saveResults}
-          className="px-4 py-2 bg-gray-900 border border-green-500 rounded hover:bg-gray-800"
-        >
+        <button onClick={saveResults} className="btn btn-secondary">
           Save to My List
         </button>
       </div>
-      <table className="min-w-full text-left border border-green-500">
-        <thead className="bg-gray-900">
+      <table className="min-w-full text-left border border-gray-200">
+        <thead className="bg-gray-50">
           <tr>
-            <th className="border border-green-500 px-2">Company Name</th>
-            <th className="border border-green-500 px-2">Website</th>
-            <th className="border border-green-500 px-2">Headquarters</th>
-            <th className="border border-green-500 px-2">Industry</th>
-            <th className="border border-green-500 px-2">Employee Size</th>
-            <th className="border border-green-500 px-2">Company LinkedIn</th>
+            <th className="border border-gray-200 px-2">Company Name</th>
+            <th className="border border-gray-200 px-2">Website</th>
+            <th className="border border-gray-200 px-2">Headquarters</th>
+            <th className="border border-gray-200 px-2">Industry</th>
+            <th className="border border-gray-200 px-2">Employee Size</th>
+            <th className="border border-gray-200 px-2">Company LinkedIn</th>
           </tr>
         </thead>
         <tbody>
           {results.map((r) => (
-            <tr key={r.id} className="hover:bg-gray-800">
-              <td className="border border-green-500 px-2">{r.companyName}</td>
-              <td className="border border-green-500 px-2">{r.domain}</td>
-              <td className="border border-green-500 px-2">{r.hq || "N/A"}</td>
-              <td className="border border-green-500 px-2">
+            <tr key={r.id} className="hover:bg-gray-100">
+              <td className="border border-gray-200 px-2">{r.companyName}</td>
+              <td className="border border-gray-200 px-2">{r.domain}</td>
+              <td className="border border-gray-200 px-2">{r.hq || "N/A"}</td>
+              <td className="border border-gray-200 px-2">
                 {r.industry || "N/A"}
               </td>
-              <td className="border border-green-500 px-2">
+              <td className="border border-gray-200 px-2">
                 {r.size || "N/A"}
               </td>
-              <td className="border border-green-500 px-2">
+              <td className="border border-gray-200 px-2">
                 {r.linkedin_url ? (
                   <a
                     href={formatLinkedInUrl(r.linkedin_url)}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-blue-400 hover:underline"
+                    className="text-primary hover:underline"
                   >
                     Link
                   </a>

--- a/frontend/src/components/UploadScreen.jsx
+++ b/frontend/src/components/UploadScreen.jsx
@@ -47,12 +47,9 @@ export function UploadScreen({ onFileUploaded }) {
   };
 
   return (
-    <div className="p-8 border border-green-500 rounded bg-gray-900 text-center text-green-400">
+    <div className="card p-8 text-center">
       <p className="mb-4">Upload a .csv file with a Domain or Company Name column.</p>
-      <button
-        onClick={handleFileSelect}
-        className="px-4 py-2 bg-black border border-green-500 rounded hover:bg-gray-800"
-      >
+      <button onClick={handleFileSelect} className="btn btn-primary">
         Upload CSV
       </button>
       <input
@@ -63,9 +60,9 @@ export function UploadScreen({ onFileUploaded }) {
         className="hidden"
       />
       {uploading && (
-        <div className="mt-4 w-full bg-gray-800 h-2 rounded">
+        <div className="mt-4 w-full bg-gray-200 h-2 rounded">
           <div
-            className="h-full bg-green-500 transition-all"
+            className="h-full bg-purple-600 transition-all"
             style={{ width: `${progress}%` }}
           />
         </div>

--- a/frontend/src/components/UserDashboard.jsx
+++ b/frontend/src/components/UserDashboard.jsx
@@ -15,25 +15,21 @@ export function UserDashboard({ token }) {
   }, [token]);
 
   if (!stats) {
-    return (
-      <div className="bg-black p-4 rounded border border-green-500 text-green-400">
-        Loading...
-      </div>
-    );
+    return <div className="card p-4">Loading...</div>;
   }
 
   return (
-    <div className="bg-black p-4 rounded border border-green-500 text-green-400 space-y-4">
+    <div className="card p-4 space-y-4">
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
         <div>
           <div className="text-lg font-bold">{stats.enrichment_count || 0}</div>
-          <div className="text-xs text-green-300">Enrichment Jobs</div>
+          <div className="text-xs text-primary">Enrichment Jobs</div>
         </div>
         <div>
           <div className="text-lg font-bold">
             {stats.last_login ? new Date(stats.last_login).toLocaleString() : "—"}
           </div>
-          <div className="text-xs text-green-300">Last Login</div>
+          <div className="text-xs text-primary">Last Login</div>
         </div>
         <div>
           <div className="text-lg font-bold">
@@ -41,7 +37,7 @@ export function UserDashboard({ token }) {
               ? new Date(stats.last_enrichment_at).toLocaleString()
               : "—"}
           </div>
-          <div className="text-xs text-green-300">Last Enrichment</div>
+          <div className="text-xs text-primary">Last Enrichment</div>
         </div>
       </div>
       {stats.activity_log && stats.activity_log.length > 0 && (


### PR DESCRIPTION
## Summary
- Restyle dashboard components to use light card layout matching login/signup theme
- Convert tables and results view to neutral backgrounds with purple accents
- Update upload/enrichment screen with shared button and progress styles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab234077908324b84cfc69d7f807f2