### PR TITLE
Remove dashboard job table header row

### DIFF
--- a/frontend/src/components/JobsTable.jsx
+++ b/frontend/src/components/JobsTable.jsx
@@ -3,15 +3,6 @@ import React from "react";
 export function JobsTable({ jobs, onSelect }) {
   return (
     <table className="w-full text-sm">
-      <thead>
-        <tr className="text-left">
-          <th className="p-2">Status</th>
-          <th className="p-2">Progress</th>
-          <th className="p-2">Created</th>
-          <th className="p-2">Attribution</th>
-          <th className="p-2">Downloads</th>
-        </tr>
-      </thead>
       <tbody>
         {jobs.map((j) => (
           <tr


### PR DESCRIPTION
## Summary
- remove jobs table header row from user dashboard

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab295b5284832484a05b51d64f6b49