### PR TITLE
feat: track latest enrichment job

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -47,6 +47,20 @@ def init_db():
                 conn.execute(
                     text("ALTER TABLE users ADD COLUMN last_enrichment_at TIMESTAMP")
                 )
+            if "last_file_name" not in user_columns:
+                conn.execute(text("ALTER TABLE users ADD COLUMN last_file_name VARCHAR"))
+            if "last_accounts_pushed" not in user_columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE users ADD COLUMN last_accounts_pushed INTEGER NOT NULL DEFAULT 0"
+                    )
+                )
+            if "last_accounts_enriched" not in user_columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE users ADD COLUMN last_accounts_enriched INTEGER NOT NULL DEFAULT 0"
+                    )
+                )
             if "activity_log" not in user_columns:
                 if engine.dialect.name == "postgresql":
                     conn.execute(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -13,8 +13,11 @@ class User(Base):
     full_name = Column(String, nullable=False)
     role = Column(String, nullable=False)
     enrichment_count = Column(Integer, default=0, nullable=False)
-    last_login = Column(DateTime, nullable=True)
-    last_enrichment_at = Column(DateTime, nullable=True)
+    last_login = Column(DateTime(timezone=True), nullable=True)
+    last_enrichment_at = Column(DateTime(timezone=True), nullable=True)
+    last_file_name = Column(String, nullable=True)
+    last_accounts_pushed = Column(Integer, default=0, nullable=False)
+    last_accounts_enriched = Column(Integer, default=0, nullable=False)
     activity_log = Column(JSON, default=list)
     account_status = Column(String, default="Active", nullable=False)
 

--- a/frontend/src/components/UserDashboard.jsx
+++ b/frontend/src/components/UserDashboard.jsx
@@ -51,6 +51,9 @@ export function UserDashboard({ token }) {
           </div>
           <div>Accounts Pushed: {lastJob?.total_records || 0}</div>
           <div>Accounts Enriched: {lastJob?.processed_records || 0}</div>
+          <div>
+            Timestamp: {lastJob?.timestamp ? new Date(lastJob.timestamp).toLocaleString() : "—"}
+          </div>
           <div className="w-full bg-gray-200 rounded-full h-2">
             <div
               className="bg-primary h-2 rounded-full"

--- a/tests/test_admin_upload.py
+++ b/tests/test_admin_upload.py
@@ -234,5 +234,8 @@ def test_upload_updates_user_stats(tmp_path):
     user = db.query(models.User).filter(models.User.email == "admin@example.com").first()
     assert user.enrichment_count == start_count + 1
     assert user.last_enrichment_at is not None and user.last_enrichment_at != prev_last
+    assert user.last_file_name == "data.csv"
+    assert user.last_accounts_pushed == 1
+    assert user.last_accounts_enriched == 1
     assert any(a["action"] == "admin_upload" for a in user.activity_log)
     db.close()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -63,6 +63,9 @@ def test_signup_and_tracking(tmp_path):
     assert user.account_status == "Active"
     assert user.last_login is None
     assert user.activity_log and user.activity_log[0]["action"] == "signup"
+    assert user.last_file_name is None
+    assert user.last_accounts_pushed == 0
+    assert user.last_accounts_enriched == 0
 
     # Sign in to update last_login
     resp = client.post(
@@ -81,6 +84,8 @@ def test_signup_and_tracking(tmp_path):
     db.refresh(user)
     assert user.enrichment_count == 1
     assert user.last_enrichment_at is not None
+    assert user.last_accounts_pushed == 0
+    assert user.last_accounts_enriched == 0
     assert any(a["action"] == "enrichment" for a in user.activity_log)
     db.close()
 


### PR DESCRIPTION
## Summary
- store last enrichment file, counts, and timestamp on users
- expose latest job info on dashboard API and UI
- track timezone-aware timestamps for user activity

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab30e12b748324adb3635d72d751c2