### PR TITLE
Add company selection and bulk download controls

### DIFF
--- a/frontend/src/components/CompanyTable.jsx
+++ b/frontend/src/components/CompanyTable.jsx
@@ -13,11 +13,14 @@ export function CompanyTable({ filters = {} }) {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
   const [total, setTotal] = useState(0);
+  const [selectedRows, setSelectedRows] = useState([]);
+  const [bulkOption, setBulkOption] = useState("page");
+  const [customCount, setCustomCount] = useState(100);
 
-  useEffect(() => {
+  const buildParams = (pageParam, sizeParam) => {
     const params = new URLSearchParams({
-      page,
-      page_size: pageSize,
+      page: pageParam,
+      page_size: sizeParam,
       sort_key: sortConfig.key,
       sort_dir: sortConfig.direction,
     });
@@ -29,6 +32,26 @@ export function CompanyTable({ filters = {} }) {
     if (filters.sizeRanges && filters.sizeRanges.length) {
       filters.sizeRanges.forEach((r) => params.append("size_range", r));
     }
+    return params;
+  };
+
+  const fetchBulk = async (limit) => {
+    const results = [];
+    let pageNum = 1;
+    const maxSize = 100;
+    while (results.length < limit) {
+      const params = buildParams(pageNum, Math.min(maxSize, limit - results.length));
+      const res = await fetch(`${API}/api/company_updated?${params.toString()}`);
+      const data = await res.json();
+      results.push(...(data.companies || []));
+      if (results.length >= data.total || (data.companies || []).length === 0) break;
+      pageNum += 1;
+    }
+    return results.slice(0, limit);
+  };
+
+  useEffect(() => {
+    const params = buildParams(page, pageSize);
     fetch(`${API}/api/company_updated?${params.toString()}`)
       .then((res) => res.json())
       .then((data) => {
@@ -72,12 +95,111 @@ export function CompanyTable({ filters = {} }) {
   const startItem = total === 0 ? 0 : (page - 1) * pageSize + 1;
   const endItem = Math.min(page * pageSize, total);
 
+  const handleRowSelect = (company, checked) => {
+    setSelectedRows((prev) => {
+      if (checked) {
+        if (prev.some((r) => r.id === company.id)) return prev;
+        return [...prev, company];
+      }
+      return prev.filter((r) => r.id !== company.id);
+    });
+  };
+
+  const allSelectedThisPage = companies.every((c) =>
+    selectedRows.some((r) => r.id === c.id)
+  );
+
+  const toggleSelectAll = (checked) => {
+    if (checked) {
+      const newRows = companies.filter(
+        (c) => !selectedRows.some((r) => r.id === c.id)
+      );
+      setSelectedRows((prev) => [...prev, ...newRows]);
+    } else {
+      setSelectedRows((prev) =>
+        prev.filter((r) => !companies.some((c) => c.id === r.id))
+      );
+    }
+  };
+
+  const handleDownload = async () => {
+    let records = [];
+    if (bulkOption === "page") {
+      records = selectedRows.length ? selectedRows : companies;
+    } else if (bulkOption === "1000") {
+      records = await fetchBulk(Math.min(1000, total));
+    } else if (bulkOption === "all") {
+      records = await fetchBulk(total);
+    } else if (bulkOption === "custom") {
+      records = await fetchBulk(Math.min(customCount, total));
+    }
+    if (!records.length) return;
+    const headers = [
+      "Company Name",
+      "Website",
+      "Headquarters",
+      "Industry",
+      "Employee Size",
+      "Company LinkedIn",
+    ];
+    const rows = records.map((r) => [
+      r.name || "N/A",
+      r.domain || "N/A",
+      r.hq || "N/A",
+      r.industry || "N/A",
+      r.size || "N/A",
+      r.linkedin_url || "N/A",
+    ]);
+    const csv = [headers.join(","), ...rows.map((row) => row.join(","))].join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "companies.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="relative">
+      <div className="flex items-center mb-2 space-x-2">
+        <select
+          value={bulkOption}
+          onChange={(e) => setBulkOption(e.target.value)}
+          className="border rounded px-2 py-1"
+        >
+          <option value="page">This page</option>
+          <option value="1000">1000 records</option>
+          <option value="all">All results</option>
+          <option value="custom">Custom number</option>
+        </select>
+        {bulkOption === "custom" && (
+          <input
+            type="number"
+            min="1"
+            value={customCount}
+            onChange={(e) => setCustomCount(Number(e.target.value))}
+            className="border rounded px-2 py-1 w-24"
+          />
+        )}
+        <button
+          onClick={handleDownload}
+          className="px-3 py-1 border rounded bg-purple-600 text-white"
+        >
+          Download
+        </button>
+      </div>
       <div className="overflow-x-auto">
         <table className="min-w-full border border-gray-200">
           <thead className="bg-gray-50">
             <tr>
+              <th className="px-4 py-2 border border-gray-200">
+                <input
+                  type="checkbox"
+                  checked={companies.length > 0 && allSelectedThisPage}
+                  onChange={(e) => toggleSelectAll(e.target.checked)}
+                />
+              </th>
               <th
                 className="px-4 py-2 border border-gray-200 cursor-pointer"
                 onClick={() => handleSort("name")}
@@ -118,6 +240,16 @@ export function CompanyTable({ filters = {} }) {
                 className="hover:bg-gray-100 transition-colors cursor-pointer"
                 onClick={() => setSelected(c)}
               >
+                <td className="px-4 py-2 border border-gray-200">
+                  <input
+                    type="checkbox"
+                    checked={selectedRows.some((r) => r.id === c.id)}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      handleRowSelect(c, e.target.checked);
+                    }}
+                  />
+                </td>
                 <td className="px-4 py-2 border border-gray-200">
                   {c.name || "N/A"}
                 </td>


### PR DESCRIPTION
## Summary
- Add checkboxes to company table rows with header toggle for selecting current page
- Provide bulk download dropdown with options for page, 1000, all results, or custom amount
- Enable CSV export of selected or bulk-fetched company records

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac40d215e4832484892fe5908e4ba8