### PR TITLE
Load environment variables from .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ pip install -r backend/requirements.txt
 uvicorn backend.app.main:app --reload
 ```
 
+The application expects a `.env` file in the working directory containing
+configuration values such as:
+
+```
+DEEPSEEK_API_KEY=your_api_key_here
+```
+
+If the file lives elsewhere, pass its path to `load_dotenv()` when starting
+the app.
+
 ## Frontend
 
 Frontend implementation is not yet provided. A future iteration would use React and Tailwind CSS to implement the upload flow, results view, dashboard, and chat panel described in the project plan.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,10 @@ from sqlalchemy import func, text, or_, and_, cast, Integer
 
 import pycountry
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 from .database import Base, engine, get_db, init_db
 from .models import User, CompanyUpdated
 from .normalization import normalize_company_name


### PR DESCRIPTION
## Summary
- load environment variables using python-dotenv before module initialization
- document need for `.env` containing `DEEPSEEK_API_KEY`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac73d195b88324a8d0c1d8450b8bdf