### PR TITLE
Handle errors when saving DeepSeek enrichment results

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -292,7 +292,11 @@ def process_job_rows(
                                 linkedin_url=data.get("linkedin_url") or None,
                             )
                         )
-                        db.commit()
+                        try:
+                            db.commit()
+                        except Exception as exc:
+                            logger.warning("Failed to persist DeepSeek record: %s", exc)
+                            db.rollback()
             except DeepSeekError as exc:
                 note = f"DeepSeek enrichment failed: {exc}"
                 logger.warning("DeepSeek enrichment failed: %s", exc)
@@ -480,7 +484,11 @@ def enrich_domains(
                                 linkedin_url=linkedin_url or None,
                             )
                         )
-                        db.commit()
+                        try:
+                            db.commit()
+                        except Exception as exc:
+                            logger.warning("Failed to persist DeepSeek record: %s", exc)
+                            db.rollback()
 
                 if sources:
                     results.append(


### PR DESCRIPTION
## Summary
- wrap database commits with error handling when persisting DeepSeek-enriched companies
- log and rollback on commit failures to avoid aborted requests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae174be42c832492bad281c8eedb8d