### PR TITLE
Normalize DeepSeek domains before saving companies

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -442,7 +442,7 @@ def enrich_domains(
                 )
 
                 company_name = fetched.get("name") or original_name
-                fetched_domain = fetched.get("domain") or domain
+                fetched_domain = normalize_domain(fetched.get("domain") or domain)
                 hq = fetched.get("hq") or (row.get("HQ") or "")
                 size = fetched.get("size") or (
                     row.get("Company Size") or row.get("Size") or ""


### PR DESCRIPTION
## Summary
- normalize domains returned from DeepSeek before storing
- ensure fallback enrichment writes records that can be looked up reliably

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1ab32954832494b86acbc7a00792