### PR TITLE
Normalize DeepSeek domains and support size ranges

### DIFF
--- a/backend/migrations/change_size_column_to_varchar.sql
+++ b/backend/migrations/change_size_column_to_varchar.sql
@@ -1,0 +1,2 @@
+ALTER TABLE company_updated
+    ALTER COLUMN size TYPE VARCHAR USING size::VARCHAR;

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -9,9 +9,9 @@ def _seed(db):
     with db.engine.begin() as conn:
         conn.execute(text("DELETE FROM company_updated"))
         data = [
-            {"n": "Google", "d": "google.com", "s": "100000"},
-            {"n": "Startup", "d": "startup.io", "s": "8"},
-            {"n": "MidCorp", "d": "midcorp.net", "s": "300"},
+            {"n": "Google", "d": "google.com", "s": "10001+"},
+            {"n": "Startup", "d": "startup.io", "s": "1-10"},
+            {"n": "MidCorp", "d": "midcorp.net", "s": "201-500"},
         ]
         for row in data:
             conn.execute(


### PR DESCRIPTION
## Summary
- convert `company_updated.size` column to `VARCHAR` so employee ranges like `1001-5000` and `10001+` persist
- update company listing filters to work with textual size ranges

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1ab32954832494b86acbc7a00792