### PR TITLE
Add health check route and tests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,14 +52,23 @@ def log_activity(user: User, action: str) -> None:
     user.activity_log = events
 
 # --- App ---
+# Allow your Namecheap site to call the API
+origins = ["https://bizdetails.xyz", "https://www.bizdetails.xyz"]
+
 app = FastAPI(title="BizDetails AI API")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # tighten in prod
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.get("/healthz")
+def healthz() -> Dict[str, bool]:
+    """Simple health check endpoint."""
+    return {"ok": True}
 
 # --- Auth / Security ---
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from test_auth import setup_app
+
+
+def test_healthz_endpoint(tmp_path):
+    app, _, _ = setup_app(tmp_path)
+    client = TestClient(app)
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}


### PR DESCRIPTION
## Summary
- configure CORS for BizDetails domains
- add `/healthz` endpoint for health checks
- cover health endpoint with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bade5c72348324ad7733fd781d061f